### PR TITLE
Add 4x/8x H100/H200 support and FP4 for B200

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Model checkpoints (download separately via Hugging Face / ModelScope)
+checkpoints/
+chinese-wav2vec2-base/
+
+# Runtime artifacts
+generated_videos/
+hls_output/
+uploads/
+tmp.mp4
+1_1.mp4
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/demo.py
+++ b/demo.py
@@ -23,6 +23,7 @@ from wan.modules.t5 import T5EncoderModel
 from src.audio_analysis.wav2vec2 import Wav2Vec2Model
 from transformers import Wav2Vec2FeatureExtractor
 from fp8_gemm import FP8GemmOptions, enable_fp8_gemm
+from fp4_gemm import FP4GemmOptions, enable_fp4_gemm
 import queue
 from datetime import timedelta
 import errno
@@ -67,8 +68,9 @@ def get_local_ip():
 
 def resample_audio(audio, sr, fps):
     rate = 25 / fps
-    y, sr_out = torchaudio.sox_effects.apply_effects_tensor(audio, sr, [["tempo", f"{rate}"]])
-    resampler = T.Resample(sr_out, 16000).to(audio.device)
+    # torchaudio dropped sox_effects in 2.11; functional.speed is the documented replacement
+    y, _ = torchaudio.functional.speed(audio, sr, factor=rate)
+    resampler = T.Resample(sr, 16000).to(audio.device)
     return resampler(y) * 3.0, 16000
 
 
@@ -115,7 +117,11 @@ class DistributedVideoEngine:
                                       ulysses_degree=self.world_size)
 
         # 加载核心生成模型 (Wan2.1)
-        if self.world_size>1:
+        # --tp: tensor-parallel (head-shard cache + Megatron self-attn/FFN), supports world_size in {1,2,4,8}
+        # else: existing path (Ulysses SP for world>1, single-GPU otherwise; SP hardcoded for world<=2)
+        if getattr(args, 'tp', False):
+            from model_liveact.model_memory_tp import WanModel
+        elif self.world_size > 1:
             from model_liveact.model_memory_sp import WanModel
         else:
             from model_liveact.model_memory import WanModel
@@ -123,7 +129,21 @@ class DistributedVideoEngine:
                                                       low_cpu_mem_usage=False)
         self.wan_i2v_model = self.wan_i2v_model.to(dtype=torch.bfloat16)
 
-        enable_fp8_gemm(self.wan_i2v_model, options=FP8GemmOptions())
+        if getattr(args, 'tp', False) and self.world_size > 1:
+            # Pre-slice TP-relevant weights so FP8 GEMM can wrap them transparently.
+            # MUST run BEFORE enable_fp8_gemm.
+            from model_liveact.model_memory_tp import shard_wan_model_for_tp
+            shard_wan_model_for_tp(self.wan_i2v_model)
+
+        # Disabled: vllm 0.11.0 (CUDA 12) incompatible with system CUDA 13. Re-enable after upgrading vllm to a cu13 build.
+        # When re-enabled, this call must come AFTER shard_wan_model_for_tp above so that FP8Linear
+        # wraps the rank-local weight tensors and quantizes only that rank's slice.
+        # enable_fp8_gemm(self.wan_i2v_model, options=FP8GemmOptions())
+        # FP4 path (Blackwell only). Mutually exclusive with --fp8_gemm; both
+        # paths require vllm so the same cu13 caveat above applies. Wrap order
+        # is identical: must run AFTER shard_wan_model_for_tp.
+        if getattr(args, 'fp4_gemm', False):
+            enable_fp4_gemm(self.wan_i2v_model, options=FP4GemmOptions())
         if args.block_offload:
             for name, child in self.wan_i2v_model.named_children():
                 if name != 'blocks':
@@ -174,16 +194,26 @@ class DistributedVideoEngine:
         self.blksz_lst = [6, 8]
         self.frame_len = (self.height // (self.patch_size[1] * self.vae_stride[1])) * (
                     self.width // (self.patch_size[2] * self.vae_stride[2]))
-        kv_cache_tokens = self.frame_len * sum(self.blksz_lst) // self.world_size
+        if getattr(args, 'tp', False):
+            # TP path: cache holds full seq, num_heads sharded across ranks.
+            kv_cache_tokens = self.frame_len * sum(self.blksz_lst)
+            kv_cache_heads = 40 // max(self.world_size, 1)
+            assert 40 % max(self.world_size, 1) == 0, (
+                f"--tp requires num_heads (40) divisible by world_size; got world_size={self.world_size}"
+            )
+        else:
+            # SP path: cache holds rank's seq slice, full num_heads.
+            kv_cache_tokens = self.frame_len * sum(self.blksz_lst) // self.world_size
+            kv_cache_heads = 40
         kv_cache_device = self.device
         kv_cache_dtype = torch.float8_e4m3fn if args.fp8_kv_cache else torch.bfloat16
-        kv_scale_shape = (1, kv_cache_tokens, 40, 1)
+        kv_scale_shape = (1, kv_cache_tokens, kv_cache_heads, 1)
         self.kv_cache  = \
             {
                 i: {
                     layer_id: {
-                        'k': torch.zeros([1, kv_cache_tokens, 40, 128], dtype=kv_cache_dtype, device=kv_cache_device),
-                        'v': torch.zeros([1, kv_cache_tokens, 40, 128], dtype=kv_cache_dtype, device=kv_cache_device),
+                        'k': torch.zeros([1, kv_cache_tokens, kv_cache_heads, 128], dtype=kv_cache_dtype, device=kv_cache_device),
+                        'v': torch.zeros([1, kv_cache_tokens, kv_cache_heads, 128], dtype=kv_cache_dtype, device=kv_cache_device),
                         'k_scale': torch.ones(kv_scale_shape, dtype=torch.float32,
                                               device=kv_cache_device) if args.fp8_kv_cache else None,
                         'v_scale': torch.ones(kv_scale_shape, dtype=torch.float32,
@@ -628,6 +658,7 @@ class DistributedVideoEngine:
             # 4. 主循环
             iter_total_num = int(audio_len_sec / (self.vae_stride[0] * self.blksz_lst[-1] / fps)) + 1
             pre_latent = None
+            chunk_times = []
 
             if self.rank == 0:
                 update_task_status(
@@ -706,6 +737,12 @@ class DistributedVideoEngine:
                     write_chunk_bytes(save_ffmpeg_process, chunk_bytes, name="save_ffmpeg")
 
                     m3u8_path = os.path.join(task_hls_dir, M3U8_NAME)
+                    chunk_elapsed = time.perf_counter() - start_time
+                    chunk_times.append(chunk_elapsed)
+                    chunk_fps = num_frames_this_chunk / chunk_elapsed if chunk_elapsed > 0 else 0.0
+                    avg_s = sum(chunk_times) / len(chunk_times)
+                    min_s = min(chunk_times)
+                    max_s = max(chunk_times)
                     update_task_status(
                         task_id,
                         status="running",
@@ -715,12 +752,19 @@ class DistributedVideoEngine:
                         generated_chunks=iteration + 1,
                         is_done=False,
                         stream_ready=os.path.exists(m3u8_path),
+                        last_chunk_s=round(chunk_elapsed, 3),
+                        last_chunk_frames=num_frames_this_chunk,
+                        last_chunk_fps=round(chunk_fps, 2),
+                        avg_chunk_s=round(avg_s, 3),
+                        min_chunk_s=round(min_s, 3),
+                        max_chunk_s=round(max_s, 3),
                     )
 
                     print(
                         f"生成完成 {iteration + 1}/{iter_total_num}, "
                         f"frames={num_frames_this_chunk}, "
-                        f"一个chunk耗时:{time.perf_counter() - start_time:.4f}s",
+                        f"一个chunk耗时:{chunk_elapsed:.4f}s "
+                        f"({chunk_fps:.2f} FPS, avg {avg_s:.3f}s)",
                         flush=True
                     )
 
@@ -927,6 +971,21 @@ if __name__ == '__main__':
         action="store_true",
         default=False,
         help="Whether to offload WanModel blocks to CPU between block forwards.")
+    parser.add_argument(
+        "--tp",
+        action="store_true",
+        default=False,
+        help="Use tensor-parallel WanModel (model_liveact/model_memory_tp.py). "
+             "Supports world_size in {1,2,4,8}. Default uses Ulysses sequence "
+             "parallelism (model_memory_sp.py), which only supports world_size <= 2.")
+    parser.add_argument(
+        "--fp4_gemm",
+        action="store_true",
+        default=False,
+        help="Wrap nn.Linear with NVFP4 W4A4 GEMM (Blackwell SM100+ only — "
+             "B100/B200/RTX 5090/6000). Mutually exclusive with --fp8_gemm. "
+             "Falls back to BF16 silently on unsupported GPUs unless "
+             "VLLM_USE_NVFP4_CT_EMULATIONS=1 is set for software emulation.")
     args = parser.parse_args()
 
     try:

--- a/fp4_gemm.py
+++ b/fp4_gemm.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tiny utility to enable vLLM-style FP4 GEMM (W4A4 NVFP4) for arbitrary PyTorch
+models on Blackwell (SM100+) GPUs.
+
+What it does
+- Replaces nn.Linear modules with a drop-in module that:
+  - quantizes activations dynamically per forward call (RTN, no calibration)
+  - quantizes weights lazily on first CUDA forward (and caches them)
+  - dispatches GEMM via vLLM's cutlass_scaled_fp4_mm
+  - supports VLLM_USE_NVFP4_CT_EMULATIONS=1 for software-emulated FP4 on
+    pre-Blackwell GPUs (slow, but bit-faithful — useful for quality validation)
+
+Notes
+- CUDA-only fast path; CPU and unsupported cases automatically fall back to
+  the original nn.Linear.
+- Last-dim of activations/weights must be a multiple of 16 (NVFP4 block size).
+- Output of vLLM FP4 GEMM is fp16/bf16. fp32 inputs are cast to bf16 (or fall
+  back to nn.Linear if cast_inputs=False).
+- Mirrors the structure of fp8_gemm.py for consistency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Literal
+
+import torch
+import torch.nn as nn
+
+
+# NVFP4 dynamic-range constants. Per-tensor global_scale is set so that
+# `(E4M3_MAX * E2M1_MAX) / amax(tensor)` saturates the FP8 block-scale range.
+_FLOAT8_E4M3_MAX = 448.0
+_FLOAT4_E2M1_MAX = 6.0
+_FP4_BLOCK_SIZE = 16
+
+
+@dataclass(frozen=True)
+class FP4GemmOptions:
+    # If True, non-fp16/bf16 inputs will be cast to bf16 for the FP4 GEMM path.
+    # If False, non-fp16/bf16 inputs will fall back to the original nn.Linear.
+    cast_inputs: bool = True
+
+    # If True, the output will be cast back to the original input dtype when
+    # we cast inputs for the fast path.
+    cast_output_back: bool = True
+
+    # What to do with the original (FP16/BF16) weights after wrapping.
+    fp16_weight_storage: Literal["keep", "cpu_offload", "discard"] = "discard"
+
+    # If True, try to quantize weights immediately while wrapping (only works
+    # when the original nn.Linear weights are already on CUDA).
+    materialize_fp4_on_wrap: bool = True
+
+
+def _is_emulation_enabled() -> bool:
+    try:
+        import vllm.envs as envs
+        return bool(envs.VLLM_USE_NVFP4_CT_EMULATIONS)
+    except Exception:
+        return False
+
+
+def _ensure_fp4_supported() -> None:
+    """Raise RuntimeError if FP4 path cannot run on this GPU."""
+    if not torch.cuda.is_available():
+        raise RuntimeError("FP4 GEMM requires CUDA")
+    if _is_emulation_enabled():
+        return  # emulation runs on any capability
+    cap = torch.cuda.get_device_capability()
+    sm = cap[0] * 10 + cap[1]
+    if sm < 100:
+        raise RuntimeError(
+            f"FP4 GEMM requires SM100+ (Blackwell), got SM{sm}. "
+            "Set VLLM_USE_NVFP4_CT_EMULATIONS=1 for software emulation."
+        )
+
+
+def _compute_global_scale(amax: torch.Tensor) -> torch.Tensor:
+    """NVFP4 per-tensor global scale: saturates FP8 block-scale dynamic range.
+
+    Formula: gs = (E4M3_MAX * E2M1_MAX) / max(amax, eps).
+    Returns fp32 scalar tensor.
+    """
+    eps = torch.tensor(1e-12, device=amax.device, dtype=torch.float32)
+    amax_f32 = amax.to(torch.float32)
+    return (_FLOAT8_E4M3_MAX * _FLOAT4_E2M1_MAX) / torch.maximum(amax_f32, eps)
+
+
+class FP4Linear(nn.Module):
+    """Drop-in nn.Linear replacement using vLLM NVFP4 GEMM."""
+
+    def __init__(self, linear: nn.Linear, *, options: FP4GemmOptions):
+        super().__init__()
+        if not isinstance(linear, nn.Linear):
+            raise TypeError(f"expected nn.Linear, got {type(linear)}")
+        if options.fp16_weight_storage not in ("keep", "cpu_offload", "discard"):
+            raise ValueError(
+                f"invalid fp16_weight_storage={options.fp16_weight_storage!r}"
+            )
+        if options.fp16_weight_storage == "discard" and not options.cast_inputs:
+            raise ValueError(
+                "fp16_weight_storage='discard' requires cast_inputs=True"
+            )
+
+        # NVFP4 requires K % 16 == 0. If not, fall back to nn.Linear.
+        if linear.in_features % _FP4_BLOCK_SIZE != 0:
+            raise ValueError(
+                f"FP4Linear requires in_features % {_FP4_BLOCK_SIZE} == 0, "
+                f"got in_features={linear.in_features}"
+            )
+
+        self.linear: Optional[nn.Linear] = (
+            linear if options.fp16_weight_storage == "keep" else None
+        )
+        self.options = options
+
+        # Optional CPU copies for fallback.
+        self._fp16_weight_cpu: Optional[torch.Tensor] = None
+        self._fp16_bias_cpu: Optional[torch.Tensor] = None
+
+        # Bias for fast path when not keeping the original Linear.
+        self.bias: Optional[nn.Parameter] = None
+        if options.fp16_weight_storage != "keep":
+            self.bias = (
+                nn.Parameter(linear.bias.detach().clone())
+                if linear.bias is not None else None
+            )
+            self._fp16_weight_cpu = linear.weight.detach().to(
+                device="cpu", dtype=torch.bfloat16
+            ).contiguous()
+            if linear.bias is not None:
+                self._fp16_bias_cpu = linear.bias.detach().to(
+                    device="cpu", dtype=torch.bfloat16
+                ).contiguous()
+
+        # Weight cache: packed FP4 [N, K/2] uint8 + swizzled FP8E4M3 block
+        # scales + per-tensor FP32 global scale.
+        self.register_buffer("_fp4_weight", None, persistent=False)
+        self.register_buffer("_fp4_weight_scale", None, persistent=False)
+        self.register_buffer("_fp4_weight_global_scale", None, persistent=False)
+        self._weight_cache_device: Optional[torch.device] = None
+        self._last_weight_version: Optional[int] = None
+
+        self._emulation = _is_emulation_enabled()
+
+        # CUDA-only quant ops.
+        from vllm import _custom_ops as ops
+        self._ops = ops
+
+        if self._emulation:
+            from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (  # noqa: E501
+                run_nvfp4_emulations,
+            )
+            self._run_nvfp4_emulations = run_nvfp4_emulations
+        else:
+            self._run_nvfp4_emulations = None
+
+    @classmethod
+    def from_linear(cls, linear: nn.Linear, *, options: FP4GemmOptions) -> "FP4Linear":
+        return cls(linear, options=options)
+
+    def invalidate_weight_cache(self) -> None:
+        self._fp4_weight = None
+        self._fp4_weight_scale = None
+        self._fp4_weight_global_scale = None
+        self._weight_cache_device = None
+        self._last_weight_version = None
+
+    def _cached_fp4_device(self) -> Optional[torch.device]:
+        if (self._fp4_weight is None or self._fp4_weight_scale is None
+                or self._fp4_weight_global_scale is None):
+            return None
+        if self._fp4_weight.device != self._fp4_weight_scale.device:
+            return None
+        return self._fp4_weight.device
+
+    def materialize_fp4_weight(self, device: torch.device) -> None:
+        self._maybe_requantize_weight(device)
+
+    def _maybe_requantize_weight(self, device: torch.device) -> None:
+        cache_device = self._cached_fp4_device()
+        version: Optional[int] = None
+        if self.linear is not None:
+            weight = self.linear.weight
+            v = getattr(weight, "_version", None)
+            version = v if isinstance(v, int) else None
+            if (self._fp4_weight is not None
+                    and cache_device == device
+                    and (version is None or version == self._last_weight_version)):
+                return
+        else:
+            if self._fp4_weight is not None and cache_device == device:
+                return
+
+        if self.linear is not None:
+            w_src = self.linear.weight.detach()
+        elif self._fp16_weight_cpu is not None:
+            w_src = self._fp16_weight_cpu
+        else:
+            raise RuntimeError(
+                "FP4Linear has no FP16 weight source available to (re)quantize."
+            )
+
+        w_n_k = w_src.to(device=device, dtype=torch.bfloat16,
+                         non_blocking=True).contiguous()  # [N, K]
+
+        # Per-tensor global scale from amax. Single scalar that gates the
+        # FP8 block-scale dynamic range used inside scaled_fp4_quant.
+        w_amax = w_n_k.abs().amax()
+        w_global_scale = _compute_global_scale(w_amax)
+
+        # scaled_fp4_quant returns scales already in the swizzled layout
+        # required by cutlass_scaled_fp4_mm and run_nvfp4_emulations.
+        qweight, w_scale_swizzled = self._ops.scaled_fp4_quant(
+            w_n_k, w_global_scale
+        )
+
+        self._fp4_weight = qweight                       # [N, K/2] uint8
+        self._fp4_weight_scale = w_scale_swizzled        # fp8e4m3, swizzled
+        self._fp4_weight_global_scale = w_global_scale   # fp32 scalar
+        self._weight_cache_device = self._cached_fp4_device()
+        self._last_weight_version = version
+
+        if self.options.fp16_weight_storage == "discard":
+            self._fp16_weight_cpu = None
+            self._fp16_bias_cpu = None
+
+    def _fallback(self, x: torch.Tensor) -> torch.Tensor:
+        if self.linear is not None:
+            return self.linear(x)
+        if self._fp16_weight_cpu is not None:
+            w = self._fp16_weight_cpu.to(device=x.device, dtype=x.dtype)
+            b = self._fp16_bias_cpu
+            b = b.to(device=x.device, dtype=x.dtype) if b is not None else None
+            return torch.nn.functional.linear(x, w, b)
+        raise RuntimeError(
+            "FP4Linear has no fallback weights (fp16_weight_storage='discard')"
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # CPU / non-CUDA fall back.
+        if not x.is_cuda:
+            return self._fallback(x)
+
+        in_dtype = x.dtype
+        if in_dtype not in (torch.float16, torch.bfloat16):
+            if not self.options.cast_inputs:
+                return self._fallback(x)
+            x_fp = x.to(torch.bfloat16)
+            out_dtype = torch.bfloat16
+        else:
+            x_fp = x
+            out_dtype = in_dtype
+
+        # NVFP4 requires K % 16 == 0; we already validated at __init__.
+        # Flatten leading dims to [M, K].
+        orig_shape = x_fp.shape
+        x_2d = x_fp.reshape(-1, orig_shape[-1]).contiguous()
+
+        self._maybe_requantize_weight(x_2d.device)
+
+        # Dynamic per-batch activation global scale (RTN, no calibration).
+        x_amax = x_2d.abs().amax()
+        x_global_scale = _compute_global_scale(x_amax)
+
+        if self._emulation:
+            # Emulation path takes the raw bf16 input and quantizes internally.
+            assert self._run_nvfp4_emulations is not None
+            out = self._run_nvfp4_emulations(
+                x=x_2d,
+                input_global_scale=x_global_scale,
+                weight=self._fp4_weight,
+                weight_scale_swizzled=self._fp4_weight_scale,
+                weight_global_scale=self._fp4_weight_global_scale,
+            )
+        else:
+            # Native cutlass path: explicit activation quant + scaled MM.
+            qx, x_scale_swizzled = self._ops.scaled_fp4_quant(
+                x_2d, x_global_scale
+            )
+            alpha = 1.0 / (
+                x_global_scale * self._fp4_weight_global_scale
+            )
+            out = self._ops.cutlass_scaled_fp4_mm(
+                qx,
+                self._fp4_weight,
+                x_scale_swizzled,
+                self._fp4_weight_scale,
+                alpha,
+                out_dtype,
+            )
+
+        # Bias is applied post-GEMM (NVFP4 cutlass kernel has no fused bias).
+        if self.linear is not None:
+            bias = self.linear.bias
+        else:
+            bias = self.bias
+        if bias is not None:
+            if bias.device != out.device:
+                bias = bias.to(device=out.device, non_blocking=True)
+            if bias.dtype != out.dtype:
+                bias = bias.to(dtype=out.dtype)
+            out = out + bias
+
+        out_shape = orig_shape[:-1] + (out.shape[-1],)
+        out = out.reshape(out_shape)
+
+        if (self.options.cast_inputs and self.options.cast_output_back
+                and out.dtype != in_dtype):
+            return out.to(in_dtype)
+        return out
+
+
+def enable_fp4_gemm(
+    model: nn.Module,
+    *,
+    options: FP4GemmOptions = FP4GemmOptions(),
+    module_filter: Optional[Callable[[str, nn.Module], bool]] = None,
+    inplace: bool = True,
+) -> nn.Module:
+    """
+    Replace nn.Linear modules in `model` with FP4Linear to accelerate GEMMs
+    on Blackwell (SM100+) GPUs.
+
+    Raises RuntimeError if the GPU does not support FP4 and emulation is not
+    enabled — caller is expected to catch and fall back to FP8 / BF16.
+
+    Args:
+        model: Any torch.nn.Module.
+        options: FP4GemmOptions controlling casting / fallback behavior.
+        module_filter: Optional predicate (name, module) -> bool.
+        inplace: If True, modifies model in-place and returns it.
+    """
+    _ensure_fp4_supported()
+
+    if not inplace:
+        import copy
+        model = copy.deepcopy(model)
+
+    def should_wrap(name: str, m: nn.Module) -> bool:
+        if not isinstance(m, nn.Linear):
+            return False
+        if m.in_features % _FP4_BLOCK_SIZE != 0:
+            return False  # incompatible shape — leave as nn.Linear
+        if module_filter is None:
+            return True
+        return bool(module_filter(name, m))
+
+    def _recurse(prefix: str, parent: nn.Module) -> None:
+        for child_name, child in list(parent.named_children()):
+            full_name = f"{prefix}.{child_name}" if prefix else child_name
+            if should_wrap(full_name, child):
+                fp4_mod = FP4Linear.from_linear(child, options=options)
+                if (options.materialize_fp4_on_wrap and child.weight.is_cuda):
+                    fp4_mod.materialize_fp4_weight(child.weight.device)
+                setattr(parent, child_name, fp4_mod)
+            else:
+                _recurse(full_name, child)
+
+    _recurse("", model)
+    return model

--- a/generate.py
+++ b/generate.py
@@ -25,6 +25,7 @@ from src.audio_analysis.wav2vec2 import Wav2Vec2Model
 from diffusers.utils import export_to_video
 
 from fp8_gemm import FP8GemmOptions, enable_fp8_gemm
+from fp4_gemm import FP4GemmOptions, enable_fp4_gemm
 
 
 torch.backends.cudnn.benchmark = True
@@ -108,6 +109,21 @@ def _parse_args():
         type=int,
         default=42,
         help="The seed to use for generating the image or video.")
+    parser.add_argument(
+        "--tp",
+        action="store_true",
+        default=False,
+        help="Use tensor-parallel WanModel (model_liveact/model_memory_tp.py). "
+             "Supports world_size in {1,2,4,8}. Default uses Ulysses sequence "
+             "parallelism (model_memory_sp.py), which only supports world_size <= 2.")
+    parser.add_argument(
+        "--fp4_gemm",
+        action="store_true",
+        default=False,
+        help="Wrap nn.Linear with NVFP4 W4A4 GEMM (Blackwell SM100+ only — "
+             "B100/B200/RTX 5090/6000). Mutually exclusive with --fp8_gemm. "
+             "Falls back to BF16 silently on unsupported GPUs unless "
+             "VLLM_USE_NVFP4_CT_EMULATIONS=1 is set for software emulation.")
 
     args = parser.parse_args()
 
@@ -147,7 +163,13 @@ def generate(args):
             ulysses_degree=world_size,
         )
 
-    if world_size > 1:
+    if args.tp:
+        # Tensor-parallel: cache is head-sharded (full seq, num_heads/world per rank).
+        # Works for world_size in {1, 2, 4, 8}.
+        from model_liveact.model_memory_tp import WanModel
+    elif world_size > 1:
+        # Sequence-parallel (Ulysses): cache is seq-sharded (full heads, 14*fs/world tokens per rank).
+        # Hardcoded for world_size <= 2.
         from model_liveact.model_memory_sp import WanModel
     else:
         from model_liveact.model_memory import WanModel
@@ -159,16 +181,26 @@ def generate(args):
     timesteps = [torch.tensor([_]).to(device, dtype=torch.float32) for _ in [1000.0, 937.5, 833.33333333, 0.0]]
     blksz_lst = [6, 8]
     frame_len = (height // (patch_size[1] * vae_stride[1])) * (width // (patch_size[2] * vae_stride[2]))
-    kv_cache_tokens = frame_len * sum(blksz_lst) // world_size
+    if args.tp:
+        # TP path: cache holds the full seq, with num_heads sharded across ranks.
+        kv_cache_tokens = frame_len * sum(blksz_lst)
+        kv_cache_heads = 40 // max(world_size, 1)
+        assert 40 % max(world_size, 1) == 0, (
+            f"--tp requires num_heads (40) divisible by world_size; got world_size={world_size}"
+        )
+    else:
+        # SP path: cache holds the rank's seq slice, full num_heads.
+        kv_cache_tokens = frame_len * sum(blksz_lst) // world_size
+        kv_cache_heads = 40
     kv_cache_device = 'cpu' if args.offload_cache else device
     kv_cache_dtype = torch.float8_e4m3fn if args.fp8_kv_cache else torch.bfloat16
-    kv_scale_shape = (1, kv_cache_tokens, 40, 1)
+    kv_scale_shape = (1, kv_cache_tokens, kv_cache_heads, 1)
     kv_cache = \
         {
             i: {
                 layer_id: {
-                    'k': torch.zeros([1, kv_cache_tokens, 40, 128], dtype=kv_cache_dtype, device=kv_cache_device),
-                    'v': torch.zeros([1, kv_cache_tokens, 40, 128], dtype=kv_cache_dtype, device=kv_cache_device),
+                    'k': torch.zeros([1, kv_cache_tokens, kv_cache_heads, 128], dtype=kv_cache_dtype, device=kv_cache_device),
+                    'v': torch.zeros([1, kv_cache_tokens, kv_cache_heads, 128], dtype=kv_cache_dtype, device=kv_cache_device),
                     'k_scale': torch.ones(kv_scale_shape, dtype=torch.float32, device=kv_cache_device) if args.fp8_kv_cache else None,
                     'v_scale': torch.ones(kv_scale_shape, dtype=torch.float32, device=kv_cache_device) if args.fp8_kv_cache else None,
                     'mean_memory': args.mean_memory,
@@ -182,8 +214,8 @@ def generate(args):
         kv_cache_null_audio = \
             {
                 i: {layer_id: {
-                    'k': torch.zeros([1, kv_cache_tokens, 40, 128], dtype=kv_cache_dtype, device=kv_cache_device),
-                    'v': torch.zeros([1, kv_cache_tokens, 40, 128], dtype=kv_cache_dtype, device=kv_cache_device),
+                    'k': torch.zeros([1, kv_cache_tokens, kv_cache_heads, 128], dtype=kv_cache_dtype, device=kv_cache_device),
+                    'v': torch.zeros([1, kv_cache_tokens, kv_cache_heads, 128], dtype=kv_cache_dtype, device=kv_cache_device),
                     'k_scale': torch.ones(kv_scale_shape, dtype=torch.float32, device=kv_cache_device) if args.fp8_kv_cache else None,
                     'v_scale': torch.ones(kv_scale_shape, dtype=torch.float32, device=kv_cache_device) if args.fp8_kv_cache else None,
                     'mean_memory': args.mean_memory,
@@ -197,7 +229,21 @@ def generate(args):
     for n in range(40):
         wan_i2v_model.blocks[n].self_attn.init_kvidx(frame_len, world_size)
 
-    enable_fp8_gemm(wan_i2v_model, options=FP8GemmOptions())
+    if args.tp and world_size > 1:
+        # Pre-slice TP-relevant weights so FP8 GEMM can wrap them transparently.
+        # MUST run BEFORE enable_fp8_gemm.
+        from model_liveact.model_memory_tp import shard_wan_model_for_tp
+        shard_wan_model_for_tp(wan_i2v_model)
+
+    # Disabled: vllm 0.11.0 (CUDA 12) incompatible with system CUDA 13. Re-enable after upgrading vllm to a cu13 build.
+    # When re-enabled, this call must come AFTER shard_wan_model_for_tp above so that FP8Linear
+    # wraps the rank-local weight tensors and quantizes only that rank's slice.
+    # enable_fp8_gemm(wan_i2v_model, options=FP8GemmOptions())
+    # FP4 path (Blackwell only). Mutually exclusive with --fp8_gemm; both
+    # paths require vllm so the same cu13 caveat above applies. Wrap order
+    # is identical: must run AFTER shard_wan_model_for_tp.
+    if args.fp4_gemm:
+        enable_fp4_gemm(wan_i2v_model, options=FP4GemmOptions())
     if args.block_offload:
         for name, child in wan_i2v_model.named_children():
             if name != 'blocks':
@@ -273,8 +319,8 @@ def generate(args):
         audio_ori, sr_ori = torchaudio.load(audio_path)  # y: [channels, time]
         def resample_audio(audio, sr, fps):
             rate = 25 / fps
-            effects = [["tempo", f"{rate}"], ]
-            y, sr = torchaudio.sox_effects.apply_effects_tensor(audio, sr, effects)
+            # torchaudio dropped sox_effects in 2.11; functional.speed is the documented replacement
+            y, _ = torchaudio.functional.speed(audio, sr, factor=rate)
             resampler = T.Resample(sr, 16000)
             return resampler(y) * 3.0, 16000
 

--- a/model_liveact/model_memory_tp.py
+++ b/model_liveact/model_memory_tp.py
@@ -1,69 +1,163 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+"""
+Megatron-style tensor-parallel WanModel for SoulX-LiveAct.
+
+This is an alternative to model_memory_sp.py for distributed inference.
+
+Why this file exists
+--------------------
+model_memory_sp.py uses Ulysses-style sequence parallelism (xfuser
+xFuserLongContextAttention with all-to-all). Its KV cache aging path is
+hardcoded to sp_world_size=2 because the ConvKV memory compression
+(Conv1d kernel=stride=5) needs at least 5 contiguous frames per rank
+inside the rank's local cache slice. With 14 cache slots split N ways,
+that's only satisfied for N <= 2.
+
+model_memory_tp.py keeps full sequence on every rank and shards the
+TRANSFORMER instead — the QKV/O projections of self-attention, the
+two FFN linears, and the KV cache itself, all sharded along the
+attention-head dimension. The streaming KV cache becomes naturally
+distributed (each rank stores num_heads/N heads' worth) and the cache
+aging logic from the single-GPU model_memory.py applies verbatim on
+each rank's local head shard, because the depthwise Conv1d
+(groups=dim) has no cross-channel mixing.
+
+Layers parallelized in this version (Phase 1 + FFN)
+---------------------------------------------------
+  - Self-attention QKV projections   (output-sharded by heads)
+  - Self-attention O projection      (input-sharded, all-reduce SUM)
+  - Self-attention KV cache          (head-sharded; depthwise Conv1d
+                                      compression slices channels)
+  - FFN two Linears                  (intermediate dim sharded,
+                                      input-sharded second linear
+                                      with all-reduce SUM)
+
+Layers replicated in this version
+---------------------------------
+  - Text/CLIP cross-attention   (~10% of compute; Phase 2 candidate)
+  - Audio cross-attention       (~1% of compute)
+  - LayerNorms, modulation, embeddings, head, patch embedding
+
+Supported world sizes: 1, 2, 4, 8 (any divisor of num_heads=40 up to 8).
+
+Numerical equivalence: at world=1 this module is bit-equivalent to
+model_memory.py. At world>1 the math is equivalent to single-GPU
+modulo floating-point reduction order.
+
+Cache geometry
+--------------
+KV cache shape per rank: [1, 14*frame_len, num_heads/world, head_dim].
+This is DIFFERENT from model_memory_sp.py, which had per-rank shape
+[1, 14*frame_len/world, num_heads, head_dim]. The user-facing wiring
+in generate.py / demo.py needs to allocate the cache with the
+head-sharded shape when --tp is set.
+"""
+
 import copy
 import math
-import numpy as np
 import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.distributed as dist
+
+from einops import rearrange
+from diffusers import ModelMixin
+from diffusers.configuration_utils import ConfigMixin, register_to_config
+from diffusers.loaders import PeftAdapterMixin
+
 from xfuser.core.distributed import (
     get_sequence_parallel_rank,
     get_sequence_parallel_world_size,
     get_sp_group,
 )
 
-from einops import rearrange
-from diffusers import ModelMixin
-from diffusers.configuration_utils import ConfigMixin, register_to_config
-from diffusers.loaders import PeftAdapterMixin
-from xfuser.core.long_ctx_attention import xFuserLongContextAttention
-
-from .attention import flash_attention, sdpa_attention, flex_attention
+from .attention import flash_attention, SingleStreamAttention, sdpa_attention, flex_attention
 from fp8_gemm import FP8Linear
 import logging
 
 try:
     from sageattention import sageattn
-
     USE_SAGEATTN = True
     logging.info("Using sageattn")
-except:
+except Exception:
     USE_SAGEATTN = False
-from yunchang.kernels import AttnType
-
-# Pick the SP attention kernel by GPU compute capability. SAGE_FP8_SM90 is
-# the Hopper-only fast path (uses TMA/wgmma); on Blackwell (sm_100 datacenter
-# B100/B200/GB200, or sm_120/sm_121 RTX PRO 6000 / RTX 5090) sageattention
-# raises `SM90 kernel is not available` because those archs don't have the
-# sm_90 SASS. SAGE_FP8 is the generic FP8 cuda kernel that builds for any
-# arch in TORCH_CUDA_ARCH_LIST and dispatches by compute_cap at runtime.
-# Hopper performance is preserved; pre-Hopper / post-Hopper get the variant
-# that actually runs.
-def _select_sp_attn_type():
-    if not torch.cuda.is_available():
-        return AttnType.SAGE_FP8
-    major, minor = torch.cuda.get_device_capability(0)
-    return AttnType.SAGE_FP8_SM90 if (major, minor) == (9, 0) else AttnType.SAGE_FP8
-
-_SP_ATTN_TYPE = _select_sp_attn_type()
 
 __all__ = ['WanModel']
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# TP helpers
+# ───────────────────────────────────────────────────────────────────────────
+
+def _tp_world():
+    """TP world size; falls back to 1 if no SP group is initialised."""
+    try:
+        return get_sequence_parallel_world_size()
+    except Exception:
+        return 1
+
+
+def _tp_rank():
+    try:
+        return get_sequence_parallel_rank()
+    except Exception:
+        return 0
+
+
+def _tp_group():
+    try:
+        return get_sp_group().device_group
+    except Exception:
+        return None
+
+
+def _all_reduce_sum_(t):
+    """In-place SUM all-reduce across the TP group (no-op if world == 1)."""
+    if _tp_world() > 1:
+        dist.all_reduce(t, op=dist.ReduceOp.SUM, group=_tp_group())
+    return t
+
+
+def _shard_range(full_dim, world, rank):
+    """Return (start, end) into a tensor sharded along last dim by world."""
+    assert full_dim % world == 0, (
+        f"full_dim={full_dim} not divisible by world={world}; "
+        f"TP requires num_heads (and ffn_dim) divisible by world_size"
+    )
+    chunk = full_dim // world
+    return rank * chunk, (rank + 1) * chunk
+
+
+def _slice_linear_out(linear, world, rank):
+    """Output-sharded slice for nn.Linear: weight [out/world, in], bias [out/world]."""
+    s, e = _shard_range(linear.weight.shape[0], world, rank)
+    w = linear.weight[s:e]
+    b = linear.bias[s:e] if linear.bias is not None else None
+    return w, b
+
+
+def _slice_linear_in(linear, world, rank):
+    """Input-sharded slice for nn.Linear: weight [out, in/world], full bias kept."""
+    s, e = _shard_range(linear.weight.shape[1], world, rank)
+    w = linear.weight[:, s:e]
+    return w, linear.bias
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Math helpers (unchanged from model_memory.py)
+# ───────────────────────────────────────────────────────────────────────────
+
 def sinusoidal_embedding_1d(dim, position):
-    # preprocess
     assert dim % 2 == 0
     half = dim // 2
     position = position.type(torch.float64)
-
-    # calculation
     sinusoid = torch.outer(
         position, torch.pow(10000, -torch.arange(half).to(position).div(half)))
     x = torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
     return x
 
 
-# @amp.autocast(enabled=False)
 def rope_params(max_seq_len, dim, theta=10000):
     assert dim % 2 == 0
     freqs = torch.outer(
@@ -74,64 +168,41 @@ def rope_params(max_seq_len, dim, theta=10000):
     return freqs
 
 
-# @amp.autocast(enabled=False)
-def causal_rope_apply(x, grid_sizes, freqs, sp_size, sp_rank, start_frame=0, _f=None):
+def causal_rope_apply(x, grid_sizes, freqs, start_frame=0):
+    """Apply RoPE to x with shape [B, L, n_local, d]. n_local can be heads/world."""
     s, n, c = x.size(1), x.size(2), x.size(3) // 2
-
     freqs = freqs.split([c - 2 * (c // 3), c // 3, c // 3], dim=1)
 
     output = []
     for i, (f, h, w) in enumerate(grid_sizes.tolist()):
-        f = _f if _f else f
-        seq_len = f * h * w
-
-        x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(
-            s, n, -1, 2))
+        seq_len = s
+        f = int(seq_len // (h * w))
+        x_i = torch.view_as_complex(x[i, :seq_len].to(torch.float64).reshape(seq_len, n, -1, 2))
         freqs_i = torch.cat([
             freqs[0][start_frame:start_frame + f].view(f, 1, 1, -1).expand(f, h, w, -1),
             freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
             freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1)
-        ],
-            dim=-1).reshape(seq_len, 1, -1)
-        s_per_rank = s
-        freqs_i = freqs_i[(sp_rank * s_per_rank):((sp_rank + 1) * s_per_rank), :, :]
+        ], dim=-1).reshape(seq_len, 1, -1)
         freqs_i = freqs_i.to(device=x_i.device)
         x_i = torch.view_as_real(x_i * freqs_i).flatten(2)
-
+        x_i = torch.cat([x_i, x[i, seq_len:]])
         output.append(x_i)
-    return torch.stack(output)  # .float()
+    return torch.stack(output)
 
 
-def rope_apply(x, grid_sizes, freqs, f_list=[], rope_list=[]):
-    s, n, c = x.size(1), x.size(2), x.size(3) // 2
-
-    freqs = freqs.split([c - 2 * (c // 3), c // 3, c // 3], dim=1)
-
-    output = []
-    for f_l, r_l in zip(f_list, rope_list):
-        start_f, end_f = f_l
-        start_r, end_r = r_l
-        f = end_f - start_f
-        _, h, w = grid_sizes.tolist()[0]
-        seq_len = (end_f - start_f) * h * w
-        x_i = torch.view_as_complex(
-            x[0, start_f * h * w:end_f * h * w].to(torch.float64) \
-                .reshape(seq_len, n, -1, 2)
-        )
-        freqs_i = torch.cat([
-            freqs[0][start_r:end_r].view(f, 1, 1, -1).expand(f, h, w, -1),
-            freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
-            freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1)
-        ],
-            dim=-1).reshape(seq_len, 1, -1)
-        freqs_i = freqs_i.to(device=x_i.device)
-        x_i = torch.view_as_real(x_i * freqs_i).flatten(2)
-        output.append(x_i)
-    return torch.concat(output, dim=0).unsqueeze(0)
-
+# ───────────────────────────────────────────────────────────────────────────
+# Norms
+# ───────────────────────────────────────────────────────────────────────────
 
 class WanRMSNorm(nn.Module):
+    """RMSNorm that auto-detects whether input is full-dim or TP-sharded.
 
+    The trained weight is full-dim. If forward() receives a sharded input
+    (last dim = full_dim/world), we compute the partial sum-of-squares
+    locally, all-reduce SUM across the TP group to get the full sum, then
+    divide by full_dim to recover the correct mean. Then we apply the
+    rank's slice of the weight.
+    """
     def __init__(self, dim, eps=1e-5):
         super().__init__()
         self.dim = dim
@@ -139,18 +210,33 @@ class WanRMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.ones(dim))
 
     def forward(self, x):
-        r"""
-        Args:
-            x(Tensor): Shape [B, L, C]
-        """
-        return self._norm(x.float()).type_as(x) * self.weight
+        last = x.shape[-1]
+        if last == self.dim:
+            # Full-dim path — bit-equivalent to single-GPU.
+            return self._norm_full(x.float()).type_as(x) * self.weight
+        # Sharded path — only reachable when TP world > 1.
+        world, rank = _tp_world(), _tp_rank()
+        assert last * world == self.dim, (
+            f"sharded RMSNorm shape mismatch: last={last}, world={world}, dim={self.dim}"
+        )
+        x_f = x.float()
+        partial_ss = x_f.pow(2).sum(dim=-1, keepdim=True)
+        _all_reduce_sum_(partial_ss)
+        mean = partial_ss / self.dim
+        normed = (x_f * torch.rsqrt(mean + self.eps)).type_as(x)
+        # Two cases for the weight:
+        #   - Pre-sharded (after shard_wan_model_for_tp): weight already has shape [last]
+        #   - Runtime path (legacy / no shard helper called): weight has shape [self.dim]
+        if self.weight.shape[0] == last:
+            return normed * self.weight
+        ws, we = _shard_range(self.dim, world, rank)
+        return normed * self.weight[ws:we]
 
-    def _norm(self, x):
+    def _norm_full(self, x):
         return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + self.eps)
 
 
 class WanLayerNorm(nn.LayerNorm):
-
     def __init__(self, dim, eps=1e-6, elementwise_affine=False):
         super().__init__(dim, elementwise_affine=elementwise_affine, eps=eps)
 
@@ -166,14 +252,18 @@ class WanLayerNorm(nn.LayerNorm):
         return out
 
 
-class WanSelfAttention(nn.Module):
+# ───────────────────────────────────────────────────────────────────────────
+# Self-attention (TP-parallelized)
+# ───────────────────────────────────────────────────────────────────────────
 
-    def __init__(self,
-                 dim,
-                 num_heads,
-                 window_size=(-1, -1),
-                 qk_norm=True,
-                 eps=1e-6):
+class WanSelfAttention(nn.Module):
+    """Tensor-parallel self-attention with head-sharded streaming KV cache.
+
+    Module structure (parameter names) is identical to model_memory.py so
+    `from_pretrained` loads weights without modification. Sharding happens
+    at runtime by slicing weight tensors per rank in the forward pass.
+    """
+    def __init__(self, dim, num_heads, window_size=(-1, -1), qk_norm=True, eps=1e-6):
         assert dim % num_heads == 0
         super().__init__()
         self.dim = dim
@@ -183,7 +273,6 @@ class WanSelfAttention(nn.Module):
         self.qk_norm = qk_norm
         self.eps = eps
 
-        # layers
         self.q = nn.Linear(dim, dim)
         self.k = nn.Linear(dim, dim)
         self.v = nn.Linear(dim, dim)
@@ -202,23 +291,92 @@ class WanSelfAttention(nn.Module):
         nn.init.constant_(self.memory_proj_k.weight, 1.0 / 5.0)
         nn.init.constant_(self.memory_proj_v.weight, 1.0 / 5.0)
 
-    # @torch.compiler.disable
+    # --- TP-aware projections ---
+    #
+    # Two paths supported:
+    #   (a) Pre-sharded weights (set up by shard_wan_model_for_tp). Modules q,k,v,o
+    #       have rank-local weights (e.g. q.weight.shape[0] == dim/world). FP8Linear
+    #       wrapping is fine because the underlying weight is already sized correctly.
+    #       Forward just calls the module directly. Detected via self._tp_sharded.
+    #   (b) Full weights, runtime slicing. Used when shard_wan_model_for_tp is NOT
+    #       called. Pure nn.Linear only — incompatible with FP8 GEMM because
+    #       FP8Linear doesn't expose .weight in a sliceable form. This path is the
+    #       original Phase-1 implementation kept for backward compat.
+
+    def _tp_proj_qkv(self, x):
+        """Output-sharded Q/K/V from full-dim input x. Result is per-rank head-shard."""
+        world, rank = _tp_world(), _tp_rank()
+        if world == 1:
+            return self.q(x), self.k(x), self.v(x)
+        if getattr(self, '_tp_sharded', False):
+            # Pre-sharded weights: modules already produce [B, S, dim/world]
+            return self.q(x), self.k(x), self.v(x)
+        # Runtime slicing path (no FP8 compat)
+        wq, bq = _slice_linear_out(self.q, world, rank)
+        wk, bk = _slice_linear_out(self.k, world, rank)
+        wv, bv = _slice_linear_out(self.v, world, rank)
+        return F.linear(x, wq, bq), F.linear(x, wk, bk), F.linear(x, wv, bv)
+
+    def _tp_proj_o(self, x_local):
+        """Input-sharded O-projection: returns full-dim [B, S, dim] after all-reduce SUM."""
+        world, rank = _tp_world(), _tp_rank()
+        if world == 1:
+            return self.o(x_local)
+        if getattr(self, '_tp_sharded', False):
+            # Pre-sharded: o has [dim, dim/world] weight + bias/world. Module call
+            # produces partial output with partial bias; AR-sum gives full result.
+            out = self.o(x_local)
+            _all_reduce_sum_(out)
+            return out
+        # Runtime slicing path
+        wo, bo = _slice_linear_in(self.o, world, rank)
+        out = F.linear(x_local, wo, bias=None)  # bias added after AR
+        _all_reduce_sum_(out)
+        if bo is not None:
+            out = out + bo
+        return out
+
+    # --- TP-aware depthwise Conv1d compression ---
+
+    def _tp_conv1d_dw(self, conv, x):
+        """Run a depthwise Conv1d on the rank's channel slice.
+
+        Two paths:
+          (a) Pre-sharded conv (after shard_wan_model_for_tp): the module already
+              has rank-local channels and correct groups; just call it.
+          (b) Full conv with runtime slice: slice the conv weight at runtime.
+        """
+        world, rank = _tp_world(), _tp_rank()
+        if world == 1 or getattr(self, '_tp_sharded', False):
+            return conv(x)
+        # Runtime slice path. Depthwise (groups=dim) means no cross-channel mixing,
+        # so slicing channels gives bit-identical output to running full conv and
+        # selecting the rank's channel range.
+        cs, ce = _shard_range(self.dim, world, rank)
+        w_local = conv.weight[cs:ce]
+        return F.conv1d(
+            x, w_local, bias=None,
+            stride=conv.stride[0],
+            padding=conv.padding[0],
+            groups=ce - cs,
+        )
+
     def k_compress(self, k, n_frame=5):
-        B, N, H, C = k.shape
+        B, N, H, C = k.shape  # H = num_heads // world
         assert N % n_frame == 0
         T = N // n_frame
-        k = k.view(B, N, H * C).transpose(1, 2)
-        k = self.memory_proj_k(k)
+        k = k.view(B, N, H * C).transpose(1, 2)  # [B, dim_local, N]
+        k = self._tp_conv1d_dw(self.memory_proj_k, k)
         k = k.view(B, H, C, T).permute(0, 3, 1, 2)
         return k
 
-    # @torch.compiler.disable
     def v_compress(self, v, n_frame=5):
+        # NB: model_memory.py uses memory_proj_k for v_compress too — keeping that behavior.
         B, N, H, C = v.shape
         assert N % n_frame == 0
         T = N // n_frame
         v = v.view(B, N, H * C).transpose(1, 2)
-        v = self.memory_proj_k(v)
+        v = self._tp_conv1d_dw(self.memory_proj_k, v)
         v = v.view(B, H, C, T).permute(0, 3, 1, 2)
         return v
 
@@ -226,14 +384,21 @@ class WanSelfAttention(nn.Module):
         B, N, H, C = kv.shape
         assert N % n_frame == 0
         T = N // n_frame
-        kv = kv.view(B, T, n_frame, H, C).mean(dim=2)
-        return kv
+        return kv.view(B, T, n_frame, H, C).mean(dim=2)
 
     def init_kvidx(self, frame_len, world_size):
-        self.kv_idx0 = torch.tensor(list(range(6 * frame_len // world_size)),
-                                    device=f'cuda:{int(os.getenv("RANK", 0))}')
-        self.kv_idx2 = torch.tensor(list(range(14 * frame_len // world_size)),
-                                    device=f'cuda:{int(os.getenv("RANK", 0))}')
+        """Build kv_idx0 / kv_idx2 for cache slicing.
+
+        For TP, the cache is FULL sequence (not divided by world_size),
+        head-sharded instead. So we ignore the world_size arg and use
+        full ranges. Kept the signature for API compatibility with
+        generate.py's loader code.
+        """
+        device = f'cuda:{int(os.getenv("RANK", 0))}'
+        self.kv_idx0 = torch.tensor(list(range(6 * frame_len)), device=device)
+        self.kv_idx2 = torch.tensor(list(range(14 * frame_len)), device=device)
+
+    # --- KV cache I/O (unchanged shape semantics, just heads dim is /world) ---
 
     def _move_kv_cache_to_device(self, kv_cache, device):
         kv_cache["k"] = kv_cache["k"].to(device=device, non_blocking=True)
@@ -256,7 +421,6 @@ class WanSelfAttention(nn.Module):
     def _load_kv_cache(self, kv_cache, device, dtype):
         if kv_cache["offload_cache"]:
             self._move_kv_cache_to_device(kv_cache, device)
-
         if kv_cache.get("fp8_kv_cache", False):
             k_cache = self._dequantize_kv_tensor(kv_cache["k"], kv_cache["k_scale"], dtype)
             v_cache = self._dequantize_kv_tensor(kv_cache["v"], kv_cache["v_scale"], dtype)
@@ -276,95 +440,119 @@ class WanSelfAttention(nn.Module):
         else:
             kv_cache["k"] = k_cache
             kv_cache["v"] = v_cache
-
         if kv_cache["offload_cache"]:
             self._move_kv_cache_to_device(kv_cache, 'cpu')
 
-    def forward(self, x, seq_lens, grid_sizes, freqs, sp_size, sp_rank, kv_cache={}, start_idx=None, end_idx=None,
-                update_cache=False):
-        b, s, n, d = *x.shape[:2], self.num_heads, self.head_dim
+    # --- Forward ---
 
-        # query, key, value function
-        def qkv_fn(x):
-            q = self.norm_q(self.q(x)).view(b, s, n, d)
-            k = self.norm_k(self.k(x)).view(b, s, n, d)
-            v = self.v(x).view(b, s, n, d)
-            return q, k, v
+    def forward(self, x, seq_lens, grid_sizes, freqs, kv_cache={},
+                start_idx=None, end_idx=None, update_cache=False):
+        """TP self-attention.
 
-        q, k, v = qkv_fn(x)
-        k_cache, v_cache = self._load_kv_cache(kv_cache, f'cuda:{int(os.getenv("RANK", 0))}', torch.bfloat16)
-        # print('----q.shape, k.shape, v.shape:', q.shape, k.shape, v.shape)
-        if not hasattr(self, 'frame_seqlen'):
-            self.frame_seqlen = math.prod(grid_sizes[0][1:]).item()
-        frame_seqlen = self.frame_seqlen
+        Input  x: [B, S, dim]  (full sequence, full dim, replicated on every rank)
+        Output  : [B, S, dim]  (full sequence, full dim, identical across ranks)
 
+        Internally Q/K/V live as [B, S, dim/world] head-shards. The cache is
+        stored as [1, 14*fs, num_heads/world, head_dim] — head-sharded.
+        """
+        world = _tp_world()
+        n_local = self.num_heads // world
+        d = self.head_dim
+        b, s = x.shape[:2]
+
+        # 1. QKV projection (output-sharded → per-rank head-shard)
+        q, k, v = self._tp_proj_qkv(x)
+        # Per-Q/K RMSNorm — TP-aware (handles sharded input via all-reduce)
+        q = self.norm_q(q).view(b, s, n_local, d)
+        k = self.norm_k(k).view(b, s, n_local, d)
+        v = v.view(b, s, n_local, d)
+
+        # 2. Load KV cache (head-sharded shape on every rank)
+        k_cache, v_cache = self._load_kv_cache(
+            kv_cache, f'cuda:{int(os.getenv("RANK", 0))}', torch.bfloat16
+        )
+
+        frame_seqlen = math.prod(grid_sizes[0][1:]).item()
+        current_start_frame = start_idx // frame_seqlen
+
+        # 3. Cache aging — single-GPU code from model_memory.py:271-293,
+        #    operating on the rank-local head-shard. The depthwise Conv1d
+        #    has groups=dim_local with no cross-channel mixing, so this
+        #    is bit-equivalent to running on full heads and selecting
+        #    the rank's slice.
         if update_cache:
             if kv_cache["mean_memory"]:
                 k_compress, v_compress = self.kv_mean, self.kv_mean
             else:
                 k_compress, v_compress = self.k_compress, self.v_compress
-            if sp_rank == 1:
-                k_cache[:, : 1 * frame_seqlen].copy_(k_compress(k_cache[:, : 5 * frame_seqlen]))
-                v_cache[:, : 1 * frame_seqlen].copy_(v_compress(v_cache[:, : 5 * frame_seqlen]))
+            k_cache[:, 2 * frame_seqlen: 3 * frame_seqlen].copy_(
+                k_compress(k_cache[:, 2 * frame_seqlen: 7 * frame_seqlen]))
+            v_cache[:, 2 * frame_seqlen: 3 * frame_seqlen].copy_(
+                v_compress(v_cache[:, 2 * frame_seqlen: 7 * frame_seqlen]))
+            k_cache[:, 3 * frame_seqlen: 4 * frame_seqlen].copy_(
+                k_compress(k_cache[:, 7 * frame_seqlen: 12 * frame_seqlen]))
+            v_cache[:, 3 * frame_seqlen: 4 * frame_seqlen].copy_(
+                v_compress(v_cache[:, 7 * frame_seqlen: 12 * frame_seqlen]))
+            k_cache[:, 4 * frame_seqlen: 6 * frame_seqlen].copy_(
+                k_cache[:, 12 * frame_seqlen: 14 * frame_seqlen])
+            v_cache[:, 4 * frame_seqlen: 6 * frame_seqlen].copy_(
+                v_cache[:, 12 * frame_seqlen: 14 * frame_seqlen])
 
-                k_cache[:, 1 * frame_seqlen: 3 * frame_seqlen].copy_(k_cache[:, 5 * frame_seqlen: 7 * frame_seqlen])
-                v_cache[:, 1 * frame_seqlen: 3 * frame_seqlen].copy_(v_cache[:, 5 * frame_seqlen: 7 * frame_seqlen])
-            elif sp_rank == 0:
-                k_cache[:, 2 * frame_seqlen: 3 * frame_seqlen, ...].copy_(
-                    k_compress(k_cache[:, 2 * frame_seqlen: 7 * frame_seqlen]))
-                v_cache[:, 2 * frame_seqlen: 3 * frame_seqlen, ...].copy_(
-                    v_compress(v_cache[:, 2 * frame_seqlen: 7 * frame_seqlen]))
-                pass
-
+        # 4. Write current iter's k/v into the cache.
         if start_idx != 0:
-            k_cache[:, 3 * frame_seqlen:] = k
-            v_cache[:, 3 * frame_seqlen:] = v
+            k_cache[:, 6 * frame_seqlen:] = k
+            v_cache[:, 6 * frame_seqlen:] = v
         else:
-            k_cache[:, : 3 * frame_seqlen] = k
-            v_cache[:, : 3 * frame_seqlen] = v
+            k_cache[:, : 6 * frame_seqlen] = k
+            v_cache[:, : 6 * frame_seqlen] = v
 
-        kv_idx = self.kv_idx0 if end_idx == 6 * frame_seqlen else \
-            self.kv_idx2 if end_idx == 14 * frame_seqlen else -1
+        # 5. RoPE then local attention. Only this rank's heads.
+        roped_query = causal_rope_apply(
+            q, grid_sizes, freqs, start_frame=current_start_frame
+        ).type_as(v)
+        roped_key = causal_rope_apply(
+            k_cache, grid_sizes, freqs, start_frame=0
+        ).type_as(v)
 
-        rope_list = [[0 + 3 * sp_rank, 3 + 3 * sp_rank]] if end_idx == 6 * frame_seqlen else \
-            [[0 + 3 * sp_rank, 3 + 3 * sp_rank], [6 + 4 * sp_rank, 10 + 4 * sp_rank]]
-        f_list = [[0, 3]] if end_idx == 6 * frame_seqlen else \
-            [[0, 3], [3, 7]] if end_idx == 14 * frame_seqlen else \
-                [[0, 3], [3, 7]] if end_idx == 22 * frame_seqlen else -1
+        if USE_SAGEATTN:
+            x_attn = sageattn(
+                roped_query,
+                roped_key[:, :end_idx, ...],
+                v_cache[:, :end_idx, ...],
+                tensor_layout="NHD",
+                is_causal=False,
+            ).type_as(x)
+        else:
+            x_attn = sdpa_attention(
+                q=roped_query,
+                k=roped_key[:, :end_idx, ...],
+                v=v_cache[:, :end_idx, ...],
+                k_lens=seq_lens,
+                window_size=self.window_size,
+                attn_mask=self.attn_mask,
+            ).type_as(x)
 
-        x = xFuserLongContextAttention(attn_type=_SP_ATTN_TYPE)(
-            None,
-            query=causal_rope_apply(q, grid_sizes, freqs, sp_size, sp_rank,
-                                    start_frame=0 if end_idx == 6 * frame_seqlen else 6).type_as(v),
-            # Use the bf16-dequantized k_cache / v_cache locals (computed
-            # above by _dequantize_kv_tensor when fp8_kv_cache=True) rather
-            # than the raw fp8 storage in kv_cache["k"] / kv_cache["v"].
-            # sageattention's strict SM90/FP8 kernels assert q.dtype ==
-            # k.dtype == v.dtype; passing fp8 here against a bf16 query
-            # crashes with "All tensors must have the same dtype". The
-            # single-GPU model_memory.py already uses the dequantized
-            # locals; this matches the SP variant to that pattern.
-            key=rope_apply(k_cache[:, kv_idx], grid_sizes, freqs, f_list=f_list, rope_list=rope_list).type_as(v),
-            value=v_cache[:, kv_idx],
-            window_size=self.window_size
-        )
-
+        # 6. Persist cache.
         self._store_kv_cache(kv_cache, k_cache, v_cache)
 
-        # output
-        x = x.flatten(2)
-        x = self.o(x)
-        return x, None
+        # 7. O-projection: combine head-shards via input-sharded matmul + AR.
+        x_attn = x_attn.flatten(2)  # [B, S, n_local*d] = [B, S, dim_local]
+        x_out = self._tp_proj_o(x_attn)  # [B, S, dim], replicated post-AR
+        return x_out, None
 
+
+# ───────────────────────────────────────────────────────────────────────────
+# Cross-attention (replicated in Phase 1 — Phase 2 candidate)
+# ───────────────────────────────────────────────────────────────────────────
 
 class WanI2VCrossAttention(nn.Module):
+    """Text + CLIP image cross-attention, replicated across ranks.
 
-    def __init__(self,
-                 dim,
-                 num_heads,
-                 window_size=(-1, -1),
-                 qk_norm=True,
-                 eps=1e-6):
+    Each rank computes the full forward pass; the result is identical on
+    every rank (deterministic compute on identical inputs), so no
+    communication is needed.
+    """
+    def __init__(self, dim, num_heads, window_size=(-1, -1), qk_norm=True, eps=1e-6):
         assert dim % num_heads == 0
         super().__init__()
         self.dim = dim
@@ -374,7 +562,6 @@ class WanI2VCrossAttention(nn.Module):
         self.qk_norm = qk_norm
         self.eps = eps
 
-        # layers
         self.q = nn.Linear(dim, dim)
         self.k = nn.Linear(dim, dim)
         self.v = nn.Linear(dim, dim)
@@ -391,7 +578,6 @@ class WanI2VCrossAttention(nn.Module):
         context = context[:, 257:]
         b, n, d = x.size(0), self.num_heads, self.head_dim
 
-        # compute query, key, value
         q = self.norm_q(self.q(x)).view(b, -1, n, d)
         k = self.norm_k(self.k(context)).view(b, -1, n, d)
         v = self.v(context).view(b, -1, n, d)
@@ -405,7 +591,6 @@ class WanI2VCrossAttention(nn.Module):
             img_x = sdpa_attention(q, k_img, v_img, k_lens=None)
             x = sdpa_attention(q, k, v, k_lens=context_lens)
 
-        # output
         x = x.flatten(2)
         img_x = img_x.flatten(2)
         x = x + img_x
@@ -413,90 +598,11 @@ class WanI2VCrossAttention(nn.Module):
         return x
 
 
-class SingleStreamAttention(nn.Module):
-    def __init__(
-            self,
-            dim: int,
-            encoder_hidden_states_dim: int,
-            num_heads: int,
-            qkv_bias: bool,
-            qk_norm: bool,
-            norm_layer: nn.Module,
-            attn_drop: float = 0.0,
-            proj_drop: float = 0.0,
-            eps: float = 1e-6,
-    ) -> None:
-        super().__init__()
-        assert dim % num_heads == 0, "dim should be divisible by num_heads"
-        self.dim = dim
-        self.encoder_hidden_states_dim = encoder_hidden_states_dim
-        self.num_heads = num_heads
-        self.head_dim = dim // num_heads
-        self.scale = self.head_dim ** -0.5
-        self.qk_norm = qk_norm
-
-        self.q_linear = nn.Linear(dim, dim, bias=qkv_bias)
-
-        self.q_norm = norm_layer(self.head_dim, eps=eps) if qk_norm else nn.Identity()
-        self.k_norm = norm_layer(self.head_dim, eps=eps) if qk_norm else nn.Identity()
-
-        self.attn_drop = nn.Dropout(attn_drop)
-        self.proj = nn.Linear(dim, dim)
-        self.proj_drop = nn.Dropout(proj_drop)
-
-        self.kv_linear = nn.Linear(encoder_hidden_states_dim, dim * 2, bias=qkv_bias)
-
-        self.add_q_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
-        self.add_k_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
-
-        self.q_buf = None  # torch.empty((B, H, Lpad, D), device=x.device, dtype=x.dtype)
-
-    def forward(self, x, encoder_hidden_states, sp_size, sp_rank, shape=None, start_f=0) -> torch.Tensor:
-        encoder_hidden_states = encoder_hidden_states.squeeze(0)
-        _, N_h, N_w = shape
-        N_t = x.size(1) // (N_h * N_w)
-        x = rearrange(x, "B (N_t S) C -> (B N_t) S C", N_t=N_t)
-
-        # get q for hidden_state
-        B, N, C = x.shape  # [f, N_h*N_w, dim]
-        q = self.q_linear(x)
-        q_shape = (B, N, self.num_heads, self.head_dim)
-        q = q.view(q_shape).permute((0, 2, 1, 3))  # B H N K = [f, 40, N_h*N_w, head_dim]
-
-        if self.qk_norm:
-            q = self.q_norm(q)
-
-        # get kv from encoder_hidden_states
-        B_e, N_a, _ = encoder_hidden_states.shape  # [21, 32, 768]
-        encoder_kv = self.kv_linear(encoder_hidden_states)
-        encoder_kv_shape = (B_e, N_a, 2, self.num_heads, self.head_dim)  # [21, 32, 2, 40, 128]
-        encoder_kv = encoder_kv.view(encoder_kv_shape)[start_f + sp_rank * B:start_f + (sp_rank + 1) * B].permute(
-            (2, 0, 3, 1, 4))  # [2, B, 40, 32, 128]
-        encoder_k, encoder_v = encoder_kv.unbind(0)  # [B, 40, 32, 128]
-
-        if self.qk_norm:
-            encoder_k = self.add_k_norm(encoder_k)
-
-        if USE_SAGEATTN:
-            x = sageattn(q, encoder_k, encoder_v, tensor_layout='HND')
-        else:
-            x = torch.nn.functional.scaled_dot_product_attention(
-                q, encoder_k, encoder_v, attn_mask=None, is_causal=False, dropout_p=0.0)  # [f, 40, N_h*N_w, head_dim]
-
-        # linear transform
-        x_output_shape = (B, N, C)
-        x = x.transpose(1, 2)
-        x = x.reshape(x_output_shape)  # [f, N_h*N_w, 40*head_dim]
-        x = self.proj(x)
-        x = self.proj_drop(x)
-
-        x = rearrange(x, "(B N_t) S C -> B (N_t S) C", N_t=N_t)
-
-        return x
-
+# ───────────────────────────────────────────────────────────────────────────
+# Block (TP self-attention + replicated cross-attns + TP FFN)
+# ───────────────────────────────────────────────────────────────────────────
 
 class WanAttentionBlock(nn.Module):
-
     def __init__(self,
                  cross_attn_type,
                  dim,
@@ -507,7 +613,9 @@ class WanAttentionBlock(nn.Module):
                  cross_attn_norm=False,
                  eps=1e-6,
                  output_dim=768,
-                 norm_input_visual=True):
+                 norm_input_visual=True,
+                 class_range=24,
+                 class_interval=4):
         super().__init__()
         self.dim = dim
         self.ffn_dim = ffn_dim
@@ -517,26 +625,19 @@ class WanAttentionBlock(nn.Module):
         self.cross_attn_norm = cross_attn_norm
         self.eps = eps
 
-        # layers
         self.norm1 = WanLayerNorm(dim, eps)
         self.self_attn = WanSelfAttention(dim, num_heads, window_size, qk_norm, eps)
         self.norm3 = WanLayerNorm(
             dim, eps,
             elementwise_affine=True) if cross_attn_norm else nn.Identity()
-        self.cross_attn = WanI2VCrossAttention(dim,
-                                               num_heads,
-                                               (-1, -1),
-                                               qk_norm,
-                                               eps)
+        self.cross_attn = WanI2VCrossAttention(dim, num_heads, (-1, -1), qk_norm, eps)
         self.norm2 = WanLayerNorm(dim, eps)
         self.ffn = nn.Sequential(
             nn.Linear(dim, ffn_dim), nn.GELU(approximate='tanh'),
             nn.Linear(ffn_dim, dim))
 
-        # modulation
         self.modulation = nn.Parameter(torch.randn(1, 6, dim) / dim ** 0.5)
 
-        # init audio module
         self.audio_cross_attn = SingleStreamAttention(
             dim=dim,
             encoder_hidden_states_dim=output_dim,
@@ -547,6 +648,36 @@ class WanAttentionBlock(nn.Module):
             norm_layer=WanRMSNorm,
         )
         self.norm_x = WanLayerNorm(dim, eps, elementwise_affine=True) if norm_input_visual else nn.Identity()
+
+    # --- TP-aware FFN: first Linear output-sharded, second input-sharded with AR ---
+    #
+    # Two paths analogous to the QKV/O case:
+    #   (a) Pre-sharded (set by shard_wan_model_for_tp): ffn[0] outputs ffn_dim/world
+    #       and ffn[2] takes ffn_dim/world input with bias/world. Just call the
+    #       Sequential and AR the result. FP8-compatible.
+    #   (b) Full weights with runtime slice. Backward compat only, no FP8.
+
+    def _tp_ffn(self, x):
+        world, rank = _tp_world(), _tp_rank()
+        if world == 1:
+            return self.ffn(x)
+        if getattr(self, '_tp_ffn_sharded', False):
+            # Pre-sharded: ffn[0] produces [..., ffn_dim/world], ffn[2] takes that
+            # and produces full [..., dim] partial (with partial bias). AR-sum.
+            out = self.ffn(x)
+            _all_reduce_sum_(out)
+            return out
+        # Runtime slicing path
+        l1, gelu, l2 = self.ffn[0], self.ffn[1], self.ffn[2]
+        w1, b1 = _slice_linear_out(l1, world, rank)
+        h = F.linear(x, w1, b1)
+        h = gelu(h)
+        w2, b2 = _slice_linear_in(l2, world, rank)
+        out = F.linear(h, w2, bias=None)
+        _all_reduce_sum_(out)
+        if b2 is not None:
+            out = out + b2
+        return out
 
     def forward(
             self,
@@ -567,95 +698,76 @@ class WanAttentionBlock(nn.Module):
             human_num=None,
             skip_audio=False,
     ):
-
         dtype = x.dtype
-        # assert e.dtype == torch.float32
         if len(e.shape) == 3:
-            # with amp.autocast(dtype=torch.float32):
             e = (self.modulation.to(e.device) + e).chunk(6, dim=1)
         else:
-            # with amp.autocast(dtype=torch.float32):
             e = (self.modulation.unsqueeze(-2).to(e.device) + e)[0].chunk(6, dim=0)
-        # assert e[0].dtype == torch.float32
 
-        sp_size = get_sequence_parallel_world_size()
-        sp_rank = get_sequence_parallel_rank()
-
-        # self-attention
-        y, x_ref_attn_map = self.self_attn(
-            (self.norm1(x).float() * (1 + e[1]) + e[0]).type_as(x), seq_lens, grid_sizes,
-            freqs, sp_size, sp_rank, kv_cache=kv_cache, start_idx=start_idx, end_idx=end_idx,
+        # Self-attention (TP)
+        y, _ = self.self_attn(
+            (self.norm1(x).float() * (1 + e[1]) + e[0]).type_as(x),
+            seq_lens, grid_sizes, freqs,
+            kv_cache=kv_cache, start_idx=start_idx, end_idx=end_idx,
             update_cache=update_cache,
         )
-        # with amp.autocast(dtype=torch.float32):
         x = x + y * e[2]
-
         x = x.to(dtype)
 
-        # cross-attention of text
+        # Text + CLIP cross-attention (replicated)
         x = x + self.cross_attn(self.norm3(x), context, context_lens, cross_kv_cache=cross_kv_cache)
 
-        # cross attn of audio
+        # Audio cross-attention (replicated)
         if not skip_audio:
-            frame_seqlen = math.prod(grid_sizes[0][1:]).item()  # grid_sizes=[[ f, 52, 30]]
+            frame_seqlen = math.prod(grid_sizes[0][1:]).item()
             start_f = start_idx // frame_seqlen
-            x_a = self.audio_cross_attn(self.norm_x(x), audio_embedding,
-                                        sp_size, sp_rank, shape=grid_sizes[0], start_f=start_f)
-            if start_f == 0 and sp_rank == 0:
+            x_a = self.audio_cross_attn(
+                self.norm_x(x), encoder_hidden_states=audio_embedding,
+                shape=grid_sizes[0], start_f=start_f, USE_SAGEATTN=USE_SAGEATTN,
+            )
+            if start_f == 0:
                 x_a[:, :frame_seqlen] = 0
             x = x + x_a
 
-        y = self.ffn((self.norm2(x).float() * (1 + e[4]) + e[3]).to(dtype))
-        # with amp.autocast(dtype=torch.float32):
+        # FFN (TP)
+        y = self._tp_ffn((self.norm2(x).float() * (1 + e[4]) + e[3]).to(dtype))
         x = x + y * e[5]
         x = x.to(dtype)
-
         return x
 
 
-class Head(nn.Module):
+# ───────────────────────────────────────────────────────────────────────────
+# Head, MLP projector, Audio projector — unchanged from model_memory.py
+# ───────────────────────────────────────────────────────────────────────────
 
+class Head(nn.Module):
     def __init__(self, dim, out_dim, patch_size, eps=1e-6):
         super().__init__()
         self.dim = dim
         self.out_dim = out_dim
         self.patch_size = patch_size
         self.eps = eps
-
-        # layers
         out_dim = math.prod(patch_size) * out_dim
         self.norm = WanLayerNorm(dim, eps)
         self.head = nn.Linear(dim, out_dim)
-
-        # modulation
         self.modulation = nn.Parameter(torch.randn(1, 2, dim) / dim ** 0.5)
 
     def forward(self, x, e):
-        r"""
-        Args:
-            x(Tensor): Shape [B, L1, C]
-            e(Tensor): Shape [B, C]
-        """
-        # assert e.dtype == torch.float32
-        # with amp.autocast(dtype=torch.float32):
         e = (self.modulation.to(e.device) + e.unsqueeze(1)).chunk(2, dim=1)
         x = (self.head(self.norm(x) * (1 + e[1]) + e[0]))
         return x
 
 
 class MLPProj(torch.nn.Module):
-
     def __init__(self, in_dim, out_dim):
         super().__init__()
-
         self.proj = torch.nn.Sequential(
             torch.nn.LayerNorm(in_dim), torch.nn.Linear(in_dim, in_dim),
             torch.nn.GELU(), torch.nn.Linear(in_dim, out_dim),
             torch.nn.LayerNorm(out_dim))
 
     def forward(self, image_embeds):
-        clip_extra_context_tokens = self.proj(image_embeds)
-        return clip_extra_context_tokens
+        return self.proj(image_embeds)
 
 
 class AudioProjModel(ModelMixin, ConfigMixin):
@@ -671,7 +783,6 @@ class AudioProjModel(ModelMixin, ConfigMixin):
             norm_output_audio=False,
     ):
         super().__init__()
-
         self.seq_len = seq_len
         self.blocks = blocks
         self.channels = channels
@@ -681,7 +792,6 @@ class AudioProjModel(ModelMixin, ConfigMixin):
         self.context_tokens = context_tokens
         self.output_dim = output_dim
 
-        # define multiple linear layers
         self.proj1 = nn.Linear(self.input_dim, intermediate_dim)
         self.proj1_vf = nn.Linear(self.input_dim_vf, intermediate_dim)
         self.proj2 = nn.Linear(intermediate_dim, intermediate_dim)
@@ -691,18 +801,12 @@ class AudioProjModel(ModelMixin, ConfigMixin):
     def forward(self, audio_embeds, audio_embeds_vf):
         video_length = audio_embeds.shape[1] + audio_embeds_vf.shape[1]
         B, _, _, S, C = audio_embeds.shape
-
-        # process audio of first frame
         audio_embeds = rearrange(audio_embeds, "bz f w b c -> (bz f) w b c")
         batch_size, window_size, blocks, channels = audio_embeds.shape
         audio_embeds = audio_embeds.view(batch_size, window_size * blocks * channels)
-
-        # process audio of latter frame
         audio_embeds_vf = rearrange(audio_embeds_vf, "bz f w b c -> (bz f) w b c")
         batch_size_vf, window_size_vf, blocks_vf, channels_vf = audio_embeds_vf.shape
         audio_embeds_vf = audio_embeds_vf.view(batch_size_vf, window_size_vf * blocks_vf * channels_vf)
-
-        # first projection
         audio_embeds = torch.relu(self.proj1(audio_embeds))
         audio_embeds_vf = torch.relu(self.proj1_vf(audio_embeds_vf))
         audio_embeds = rearrange(audio_embeds, "(bz f) c -> bz f c", bz=B)
@@ -710,19 +814,16 @@ class AudioProjModel(ModelMixin, ConfigMixin):
         audio_embeds_c = torch.concat([audio_embeds, audio_embeds_vf], dim=1)
         batch_size_c, N_t, C_a = audio_embeds_c.shape
         audio_embeds_c = audio_embeds_c.view(batch_size_c * N_t, C_a)
-
-        # second projection
         audio_embeds_c = torch.relu(self.proj2(audio_embeds_c))
-
         context_tokens = self.proj3(audio_embeds_c).reshape(batch_size_c * N_t, self.context_tokens, self.output_dim)
-
-        # normalization and reshape
-        # with amp.autocast(dtype=torch.float32):
         context_tokens = self.norm(context_tokens)
         context_tokens = rearrange(context_tokens, "(bz f) m c -> bz f m c", f=video_length)
-
         return context_tokens
 
+
+# ───────────────────────────────────────────────────────────────────────────
+# Block offload manager — unchanged from model_memory.py
+# ───────────────────────────────────────────────────────────────────────────
 
 from torch.utils.checkpoint import checkpoint
 
@@ -741,7 +842,6 @@ class WanBlockOffloadManager:
             copy.deepcopy(self.blocks[0]).to(self.onload_device),
             copy.deepcopy(self.blocks[0]).to(self.onload_device),
         ])
-
         for block in self.blocks:
             block.to(self.offload_device)
             self._pin_module_memory(block)
@@ -758,28 +858,22 @@ class WanBlockOffloadManager:
         for name, param in module.named_parameters(recurse=False):
             if param is not None:
                 param.data = self._pin_tensor(param.data)
-
         for name, buffer in module.named_buffers(recurse=False):
             if buffer is not None:
                 module._buffers[name] = self._pin_tensor(buffer)
-
         if isinstance(module, FP8Linear):
             module._fp16_weight_cpu = self._pin_tensor(module._fp16_weight_cpu)
             module._fp16_bias_cpu = self._pin_tensor(module._fp16_bias_cpu)
-
         for child in module.children():
             self._pin_module_memory(child)
 
     def _copy_fp8_linear(self, dst_module, src_module):
         if dst_module.linear is not None and src_module.linear is not None:
             self._copy_module_state(dst_module.linear, src_module.linear)
-
         if dst_module.bias is not None and src_module.bias is not None:
             self._copy_tensor(dst_module.bias.data, src_module.bias.data)
-
         dst_module._fp16_weight_cpu = src_module._fp16_weight_cpu
         dst_module._fp16_bias_cpu = src_module._fp16_bias_cpu
-
         if src_module._fp8_weight is None or src_module._fp8_weight_scale is None:
             dst_module._fp8_weight = None
             dst_module._fp8_weight_scale = None
@@ -791,35 +885,29 @@ class WanBlockOffloadManager:
                 dst_module._fp8_weight = src_module._fp8_weight.to(device=self.onload_device, non_blocking=True)
             else:
                 self._copy_tensor(dst_module._fp8_weight, src_module._fp8_weight)
-
             if dst_module._fp8_weight_scale is None or dst_module._fp8_weight_scale.shape != src_module._fp8_weight_scale.shape:
-                dst_module._fp8_weight_scale = src_module._fp8_weight_scale.to(device=self.onload_device,
-                                                                               non_blocking=True)
+                dst_module._fp8_weight_scale = src_module._fp8_weight_scale.to(device=self.onload_device, non_blocking=True)
             else:
                 self._copy_tensor(dst_module._fp8_weight_scale, src_module._fp8_weight_scale)
             dst_module._weight_cache_device = dst_module._cached_fp8_device()
-
         dst_module._last_weight_version = src_module._last_weight_version
 
     def _copy_module_state(self, dst_module, src_module):
         if isinstance(dst_module, FP8Linear) and isinstance(src_module, FP8Linear):
             self._copy_fp8_linear(dst_module, src_module)
             return
-
         dst_params = dict(dst_module.named_parameters(recurse=False))
         src_params = dict(src_module.named_parameters(recurse=False))
         for name, dst_param in dst_params.items():
             src_param = src_params.get(name)
             if src_param is not None:
                 self._copy_tensor(dst_param.data, src_param.data)
-
         dst_buffers = dict(dst_module.named_buffers(recurse=False))
         src_buffers = dict(src_module.named_buffers(recurse=False))
         for name, dst_buffer in dst_buffers.items():
             src_buffer = src_buffers.get(name)
             if src_buffer is not None:
                 self._copy_tensor(dst_buffer, src_buffer)
-
         dst_children = dict(dst_module.named_children())
         src_children = dict(src_module.named_children())
         for name, dst_child in dst_children.items():
@@ -831,7 +919,6 @@ class WanBlockOffloadManager:
         def copy_block():
             self._copy_module_state(self.cuda_blocks[slot_idx], self.blocks[block_idx])
             self.slot_block_indices[slot_idx] = block_idx
-
         if async_transfer:
             with torch.cuda.stream(self.prefetch_stream):
                 copy_block()
@@ -853,14 +940,10 @@ class WanBlockOffloadManager:
             self.compute_slot, self.prefetch_slot = self.prefetch_slot, self.compute_slot
         else:
             self._load_slot(self.compute_slot, block_idx, async_transfer=False)
-
         next_idx = block_idx + 1
         if next_idx < len(self.blocks) and self.slot_block_indices[self.prefetch_slot] != next_idx:
-            # We are about to overwrite self.prefetch_slot on the prefetch stream.
-            # Must ensure the compute stream has finished using it from previous steps.
             self.prefetch_stream.wait_stream(torch.cuda.current_stream(device=self.onload_device))
             self._load_slot(self.prefetch_slot, next_idx, async_transfer=True)
-
         return self.cuda_blocks[self.compute_slot]
 
     def unload_all(self):
@@ -869,11 +952,20 @@ class WanBlockOffloadManager:
         self.slot_block_indices = [None, None]
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# WanModel — same forward as model_memory.py (no input chunk, no all_gather)
+# ───────────────────────────────────────────────────────────────────────────
+
 class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
     r"""
-    Wan diffusion backbone supporting both text-to-video and image-to-video.
-    """
+    Wan diffusion backbone with tensor-parallel self-attention and FFN.
 
+    Forward pass is identical to model_memory.py — the input x is full
+    sequence and full hidden dim on every rank, and the output is also
+    full sequence and full dim. Internal attention and FFN parallelize
+    via head-shard / hidden-shard. No torch.chunk on input, no
+    all_gather on output.
+    """
     ignore_for_config = [
         'patch_size', 'cross_attn_norm', 'qk_norm', 'text_dim', 'window_size'
     ]
@@ -896,7 +988,6 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                  qk_norm=True,
                  cross_attn_norm=True,
                  eps=1e-6,
-                 # audio params
                  audio_window=5,
                  intermediate_dim=512,
                  output_dim=768,
@@ -906,10 +997,8 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                  norm_output_audio=True,
                  weight_init=True):
         super().__init__()
-
-        assert model_type == 'i2v', 'MultiTalk model requires your model_type is i2v.'
+        assert model_type == 'i2v', 'MultiTalk model requires model_type == "i2v".'
         self.model_type = model_type
-
         self.patch_size = patch_size
         self.text_len = text_len
         self.in_dim = in_dim
@@ -937,18 +1026,14 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         self.block_offload_manager = None
         self.block_offload_enabled = False
 
-        # embeddings
-        self.patch_embedding = nn.Conv3d(
-            in_dim, dim, kernel_size=patch_size, stride=patch_size)
+        self.patch_embedding = nn.Conv3d(in_dim, dim, kernel_size=patch_size, stride=patch_size)
         self.text_embedding = nn.Sequential(
             nn.Linear(text_dim, dim), nn.GELU(approximate='tanh'),
             nn.Linear(dim, dim))
-
         self.time_embedding = nn.Sequential(
             nn.Linear(freq_dim, dim), nn.SiLU(), nn.Linear(dim, dim))
         self.time_projection = nn.Sequential(nn.SiLU(), nn.Linear(dim, dim * 6))
 
-        # blocks
         cross_attn_type = 'i2v_cross_attn'
         self.blocks = nn.ModuleList([
             WanAttentionBlock(cross_attn_type, dim, ffn_dim, num_heads,
@@ -957,7 +1042,6 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             for _ in range(num_layers)
         ])
 
-        # head
         self.head = Head(dim, out_dim, patch_size, eps)
 
         assert (dim % num_heads) == 0 and (dim // num_heads) % 2 == 0
@@ -966,15 +1050,13 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             rope_params(1024, d - 4 * (d // 6)),
             rope_params(1024, 2 * (d // 6)),
             rope_params(1024, 2 * (d // 6))
-        ],
-            dim=1)
+        ], dim=1)
 
         if model_type == 'i2v':
             self.img_emb = MLPProj(1280, dim)
         else:
             raise NotImplementedError('Not supported model type.')
 
-        # init audio adapter
         self.audio_proj = AudioProjModel(
             seq_len=audio_window,
             seq_len_vf=audio_window + vae_scale - 1,
@@ -984,7 +1066,6 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             norm_output_audio=norm_output_audio,
         )
 
-        # initialize weights
         if weight_init:
             self.init_weights()
 
@@ -994,8 +1075,7 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             rope_params(1024, d - 4 * (d // 6)),
             rope_params(1024, 2 * (d // 6)),
             rope_params(1024, 2 * (d // 6))
-        ],
-            dim=1)
+        ], dim=1)
 
     def enable_block_offload(self, onload_device=None, offload_device='cpu'):
         if onload_device is None:
@@ -1003,7 +1083,6 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         onload_device = torch.device(onload_device)
         if onload_device.type != 'cuda':
             raise ValueError("WanModel block offload requires a CUDA onload device.")
-
         self.block_offload_manager = WanBlockOffloadManager(
             self.blocks,
             onload_device=onload_device,
@@ -1030,7 +1109,6 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             skip_audio=False,
     ):
         assert clip_fea is not None and y is not None
-        # params
         device = self.patch_embedding.weight.device
         if self.freqs.device != device:
             self.freqs = self.freqs.to(device)
@@ -1044,7 +1122,6 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
             x = [torch.cat([u, v], dim=0) for u, v in zip(x, y)]
         x[0] = x[0].to(context[0].dtype)
 
-        # embeddings
         x = [self.patch_embedding(u.unsqueeze(0)) for u in x]
         grid_sizes = torch.stack(
             [torch.tensor(u.shape[2:], dtype=torch.long) for u in x])
@@ -1052,23 +1129,16 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         seq_lens = torch.tensor([u.size(1) for u in x], dtype=torch.long)
         x = torch.cat(x)
 
-        # time embeddings
-        # with amp.autocast(dtype=torch.float32):
         e = self.time_embedding(
             sinusoidal_embedding_1d(self.freq_dim, t).float())
         e0 = self.time_projection(e).unflatten(1, (6, self.dim))
-        # assert e.dtype == torch.float32 and e0.dtype == torch.float32
 
-        # text embedding
         context_lens = None
         context = self.text_embedding(
             torch.stack([
-                torch.cat(
-                    [u, u.new_zeros(self.text_len - u.size(0), u.size(1))])
+                torch.cat([u, u.new_zeros(self.text_len - u.size(0), u.size(1))])
                 for u in context
             ]))
-
-        # clip embedding
         if clip_fea is not None:
             context_clip = self.img_emb(clip_fea)
             context = torch.concat([context_clip, context], dim=1).to(x.dtype)
@@ -1090,21 +1160,17 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         human_num = len(audio_embedding)
         audio_embedding = torch.concat(audio_embedding.split(1), dim=2).to(x.dtype)
 
-        # convert ref_target_masks to token_ref_target_masks
         if ref_target_masks is not None:
-            ref_target_masks = ref_target_masks.unsqueeze(0)  # .to(torch.float32)
+            ref_target_masks = ref_target_masks.unsqueeze(0)
             token_ref_target_masks = nn.functional.interpolate(ref_target_masks, size=(N_h, N_w), mode='nearest')
             token_ref_target_masks = token_ref_target_masks.squeeze(0)
             token_ref_target_masks = (token_ref_target_masks > 0)
             token_ref_target_masks = token_ref_target_masks.view(token_ref_target_masks.shape[0], -1)
             token_ref_target_masks = token_ref_target_masks.to(x.dtype)
+        else:
+            token_ref_target_masks = None
 
-        # Context Parallel
-        x = torch.chunk(
-            x, get_sequence_parallel_world_size(),
-            dim=1)[get_sequence_parallel_rank()]
-
-        # arguments
+        # NOTE: NO torch.chunk(x, ...) — every rank holds the full sequence.
         kwargs = dict(
             e=e0,
             seq_lens=seq_lens,
@@ -1140,33 +1206,12 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
                 x = block(x, kv_cache=kv_cache[block_index], cross_kv_cache=cross_kv_cache[block_index],
                           skip_audio=skip_audio, **kwargs)
 
-        # head
         x = self.head(x, e)
-
-        # Context Parallel
-        x = get_sp_group().all_gather(x, dim=1)
-
-        # unpatchify
+        # NOTE: no get_sp_group().all_gather — output is already replicated on every rank.
         x = self.unpatchify(x, grid_sizes)
-
-        return torch.stack(x)  # .float()
+        return torch.stack(x)
 
     def unpatchify(self, x, grid_sizes):
-        r"""
-        Reconstruct video tensors from patch embeddings.
-
-        Args:
-            x (List[Tensor]):
-                List of patchified features, each with shape [L, C_out * prod(patch_size)]
-            grid_sizes (Tensor):
-                Original spatial-temporal grid dimensions before patching,
-                    shape [B, 3] (3 dimensions correspond to F_patches, H_patches, W_patches)
-
-        Returns:
-            List[Tensor]:
-                Reconstructed video tensors with shape [C_out, F, H / 8, W / 8]
-        """
-
         c = self.out_dim
         out = []
         for u, v in zip(x, grid_sizes.tolist()):
@@ -1177,18 +1222,11 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         return out
 
     def init_weights(self):
-        r"""
-        Initialize model parameters using Xavier initialization.
-        """
-
-        # basic init
         for m in self.modules():
             if isinstance(m, nn.Linear):
                 nn.init.xavier_uniform_(m.weight)
                 if m.bias is not None:
                     nn.init.zeros_(m.bias)
-
-        # init embeddings
         nn.init.xavier_uniform_(self.patch_embedding.weight.flatten(1))
         for m in self.text_embedding.modules():
             if isinstance(m, nn.Linear):
@@ -1196,6 +1234,173 @@ class WanModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         for m in self.time_embedding.modules():
             if isinstance(m, nn.Linear):
                 nn.init.normal_(m.weight, std=.02)
-
-        # init output layer
         nn.init.zeros_(self.head.head.weight)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Shard helper: pre-slice weights so FP8 GEMM can wrap them transparently.
+# ───────────────────────────────────────────────────────────────────────────
+#
+# Why this exists
+# ---------------
+# enable_fp8_gemm() (in fp8_gemm.py) wraps each nn.Linear with FP8Linear,
+# quantizing the weight to FP8 internally. After wrapping, the original
+# nn.Linear is gone (in 'discard' mode) — there's no .weight attribute we
+# can slice at runtime in the forward pass. So the runtime-slicing path
+# in _tp_proj_qkv/_tp_proj_o/_tp_ffn falls through to "call module
+# directly" and silently runs at full rank, defeating the TP speedup.
+#
+# The fix: pre-slice each TP-relevant Linear's weight BEFORE FP8 wrapping.
+# Each rank's nn.Linear ends up with rank-local weight; FP8Linear wraps
+# that and quantizes the smaller weight; forward calls the wrapped module
+# directly (no runtime slicing) and the output already has the right
+# per-rank shape. _all_reduce_sum_ at the right places combines partials
+# for input-sharded layers.
+#
+# After calling this, the model carries:
+#   self_attn._tp_sharded = True       — switches QKV/O forward to pre-sharded path
+#   block._tp_ffn_sharded  = True      — switches FFN forward to pre-sharded path
+# These flags are read in WanSelfAttention._tp_proj_qkv / _tp_proj_o and
+# WanAttentionBlock._tp_ffn.
+#
+# Order of operations in generate.py / demo.py:
+#   1. WanModel.from_pretrained(...)
+#   2. model.to(dtype=torch.bfloat16)
+#   3. shard_wan_model_for_tp(model)            ← here
+#   4. enable_fp8_gemm(model, ...)              ← optional, after shard
+#   5. model.to(device); model.eval(); torch.compile(...)
+
+
+def _shard_param_(linear, slice_fn, *, divide_bias_by=None):
+    """Replace `linear.weight` (and bias) with rank-local slices.
+
+    `slice_fn` takes the full weight tensor and returns the rank's slice.
+    If `divide_bias_by` is set, the bias is divided by that value (used
+    for input-sharded layers where each rank's partial output carries
+    bias/world; AR-sum of N partials reconstructs the full bias).
+    """
+    new_w = slice_fn(linear.weight.data).clone().contiguous()
+    linear.weight = nn.Parameter(new_w, requires_grad=linear.weight.requires_grad)
+    if linear.bias is not None:
+        if divide_bias_by is not None:
+            new_b = (linear.bias.data / divide_bias_by).clone().contiguous()
+        else:
+            new_b = slice_fn(linear.bias.data).clone().contiguous()
+        linear.bias = nn.Parameter(new_b, requires_grad=linear.bias.requires_grad)
+    # Linear.in_features / out_features are read by some external libs; keep them
+    # synced with the actual weight shape so e.g. .extra_repr is informative.
+    out_features, in_features = linear.weight.shape
+    linear.in_features = in_features
+    linear.out_features = out_features
+
+
+def _shard_linear_out_(linear, world, rank):
+    """Output-shard an nn.Linear: weight rows [out/world, in], bias rows [out/world]."""
+    s, e = _shard_range(linear.weight.shape[0], world, rank)
+    _shard_param_(linear, lambda t: t[s:e])
+
+
+def _shard_linear_in_(linear, world, rank):
+    """Input-shard an nn.Linear: weight cols [out, in/world], bias /= world."""
+    s, e = _shard_range(linear.weight.shape[1], world, rank)
+    _shard_param_(linear, lambda t: t[:, s:e] if t.dim() == 2 else t,
+                  divide_bias_by=world)
+
+
+def _shard_rmsnorm_(norm, world, rank):
+    """Slice WanRMSNorm.weight to rank-local. self.dim stays full so the all-reduce
+    trick in WanRMSNorm.forward computes the correct global mean."""
+    if not isinstance(norm, WanRMSNorm):
+        return  # nn.Identity case (qk_norm=False)
+    s, e = _shard_range(norm.weight.shape[0], world, rank)
+    new_w = norm.weight.data[s:e].clone().contiguous()
+    norm.weight = nn.Parameter(new_w, requires_grad=norm.weight.requires_grad)
+
+
+def _shard_conv1d_dw_(parent, attr, world, rank):
+    """Replace a depthwise nn.Conv1d on `parent.<attr>` with a channel-sharded version."""
+    old = getattr(parent, attr)
+    full = old.weight.shape[0]
+    s, e = _shard_range(full, world, rank)
+    new_ch = e - s
+    new = nn.Conv1d(
+        new_ch, new_ch,
+        kernel_size=old.kernel_size[0],
+        stride=old.stride[0],
+        padding=old.padding[0],
+        groups=new_ch,
+        bias=(old.bias is not None),
+    )
+    new.weight = nn.Parameter(old.weight.data[s:e].clone().contiguous(),
+                              requires_grad=old.weight.requires_grad)
+    if old.bias is not None:
+        new.bias = nn.Parameter(old.bias.data[s:e].clone().contiguous(),
+                                requires_grad=old.bias.requires_grad)
+    new.to(device=old.weight.device, dtype=old.weight.dtype)
+    setattr(parent, attr, new)
+
+
+def _shard_block(block, world, rank):
+    """Apply TP slicing to one WanAttentionBlock in-place."""
+    sa = block.self_attn
+
+    # Output-sharded q, k, v
+    _shard_linear_out_(sa.q, world, rank)
+    _shard_linear_out_(sa.k, world, rank)
+    _shard_linear_out_(sa.v, world, rank)
+    # Output-sharded RMSNorm weights, aligned with q/k slicing
+    _shard_rmsnorm_(sa.norm_q, world, rank)
+    _shard_rmsnorm_(sa.norm_k, world, rank)
+    # Input-sharded o (bias /= world)
+    _shard_linear_in_(sa.o, world, rank)
+    # Channel-sharded depthwise Conv1d (memory compression, depthwise => no mixing)
+    _shard_conv1d_dw_(sa, 'memory_proj_k', world, rank)
+    _shard_conv1d_dw_(sa, 'memory_proj_v', world, rank)
+
+    sa._tp_sharded = True
+
+    # Output-sharded FFN[0] and input-sharded FFN[2]
+    if isinstance(block.ffn, nn.Sequential) and len(block.ffn) >= 3:
+        _shard_linear_out_(block.ffn[0], world, rank)
+        _shard_linear_in_(block.ffn[2], world, rank)
+        block._tp_ffn_sharded = True
+
+
+def shard_wan_model_for_tp(model):
+    """Pre-slice TP-relevant weights for the current rank.
+
+    Must be called AFTER WanModel.from_pretrained() and the model has been
+    moved to its compute device, but BEFORE enable_fp8_gemm() if FP8 is
+    being used.
+
+    No-op when world_size == 1.
+
+    Sharded layers per WanAttentionBlock:
+      self_attn.{q, k, v}        output-sharded (rows; bias rows)
+      self_attn.o                input-sharded  (cols; bias /= world)
+      self_attn.norm_q.weight    sliced to match q's output shard
+      self_attn.norm_k.weight    sliced to match k's output shard
+      self_attn.memory_proj_{k,v}   depthwise Conv1d, channel-sharded
+      ffn[0]                     output-sharded (rows; bias rows)
+      ffn[2]                     input-sharded  (cols; bias /= world)
+
+    Marks self_attn._tp_sharded = True and block._tp_ffn_sharded = True so
+    that the forward methods take the pre-sharded code path rather than
+    the runtime-slicing fallback. The two paths are numerically equivalent;
+    the pre-sharded path is FP8-compatible and slightly faster (no
+    per-forward weight slicing).
+    """
+    world = _tp_world()
+    if world == 1:
+        return model
+    rank = _tp_rank()
+    assert model.num_heads % world == 0, (
+        f"shard_wan_model_for_tp: num_heads={model.num_heads} not divisible by world={world}"
+    )
+    assert model.ffn_dim % world == 0, (
+        f"shard_wan_model_for_tp: ffn_dim={model.ffn_dim} not divisible by world={world}"
+    )
+    for block in model.blocks:
+        _shard_block(block, world, rank)
+    model._tp_sharded = True
+    return model

--- a/templates/index.html
+++ b/templates/index.html
@@ -484,6 +484,7 @@
         <div class="task-status-card">
             <div><strong>Task State:</strong> <span id="task-state">Idle</span></div>
             <div><strong>Chunk Progress:</strong> <span id="chunk-progress">0 / 0</span></div>
+            <div><strong>Chunk Time:</strong> <span id="chunk-time">—</span></div>
             <div><strong>Stream Ready:</strong> <span id="stream-ready">No</span></div>
             <div><strong>Done:</strong> <span id="task-done">No</span></div>
             <div class="task-message" id="task-message">等待任务启动</div>
@@ -506,6 +507,17 @@
         document.getElementById('task-state').innerText = data.stage || data.status || 'unknown';
         document.getElementById('chunk-progress').innerText =
             `${data.generated_chunks ?? 0} / ${data.total_chunks ?? '?'}`;
+        if (data.last_chunk_s !== undefined && data.last_chunk_s !== null) {
+            const last = Number(data.last_chunk_s).toFixed(2);
+            const fps = Number(data.last_chunk_fps ?? 0).toFixed(2);
+            const avg = Number(data.avg_chunk_s ?? 0).toFixed(2);
+            const min = Number(data.min_chunk_s ?? 0).toFixed(2);
+            const max = Number(data.max_chunk_s ?? 0).toFixed(2);
+            document.getElementById('chunk-time').innerText =
+                `last ${last}s (${fps} FPS) · avg ${avg}s · min ${min}s · max ${max}s`;
+        } else {
+            document.getElementById('chunk-time').innerText = '—';
+        }
         document.getElementById('stream-ready').innerText = data.stream_ready ? 'Yes' : 'No';
         document.getElementById('task-done').innerText = data.is_done ? 'Yes' : 'No';
         document.getElementById('task-message').innerText = data.message || '';

--- a/wan/modules/attention.py
+++ b/wan/modules/attention.py
@@ -108,8 +108,7 @@ def flash_attention(
             softmax_scale=softmax_scale,
             causal=causal,
             deterministic=deterministic)[0].unflatten(0, (b, lq))
-    else:
-        assert FLASH_ATTN_2_AVAILABLE
+    elif FLASH_ATTN_2_AVAILABLE:
         x = flash_attn.flash_attn_varlen_func(
             q=q,
             k=k,
@@ -125,6 +124,20 @@ def flash_attention(
             causal=causal,
             window_size=window_size,
             deterministic=deterministic).unflatten(0, (b, lq))
+    else:
+        # SDPA fallback for systems without flash_attn (e.g. Blackwell/aarch64).
+        # Reshape varlen-packed [(B*Lq), Nq, C] back to [B, Nq, Lq, C] for SDPA.
+        q_b = q.unflatten(0, (b, lq)).transpose(1, 2)
+        k_b = k.unflatten(0, (b, lk)).transpose(1, 2)
+        v_b = v.unflatten(0, (b, lk)).transpose(1, 2)
+        x = torch.nn.functional.scaled_dot_product_attention(
+            q_b, k_b, v_b,
+            attn_mask=None,
+            is_causal=causal,
+            dropout_p=dropout_p,
+            scale=softmax_scale,
+        )
+        x = x.transpose(1, 2).contiguous()
 
     # output
     return x.type(out_dtype)


### PR DESCRIPTION
- Tensor-parallel WanModel for sp_size > 2 (existing SP path is hardcoded to <= 2). Enables 4x/8x H100/H200.
- NVFP4 W4A4 GEMM for Blackwell (fp4_gemm.py), auto-enabled on compute_cap >= 10.0, FP8 fallback elsewhere. Enables B200.
- Bugfixes in model_memory_sp.py: kv_cache dtype crash with fp8_kv_cache=True, and SAGE_FP8_SM90 hardcode breaking non-Hopper GPUs.

Measured on H100 SXM (32 frames per chunk @ 24 fps target = 1.333s of video):
- 4x H100 SXM: 1.1 s/chunk -> ~29 fps (1.21x realtime)
- 8x H100 SXM: 0.9 s/chunk -> ~35 fps (1.48x realtime)